### PR TITLE
Better tags

### DIFF
--- a/app.go
+++ b/app.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -269,4 +270,35 @@ func (a *App) PickFolder() string {
 		println("ERR: File picker failed")
 	}
 	return path
+}
+
+func (a *App) ShowPathInExplorer(path string) error {
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+
+	// if is dir
+	var folder string
+	if fileInfo.IsDir() {
+		folder = path
+	} else {
+		folder = filepath.Dir(path)
+	}
+
+	if runtime.GOOS == "windows" {
+		cmd := exec.Command("explorer", folder)
+		err := cmd.Run()
+		if err != nil {
+			return err
+		}
+	} else {
+		cmd := exec.Command("xdg-open", folder)
+		err := cmd.Run()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/app.go
+++ b/app.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/ncruces/zenity"
 	rlbot "github.com/swz-git/go-interface"
@@ -21,6 +22,20 @@ func (a *App) IgnoreMe(
 ) {
 }
 
+func (a *App) GetDefaultPath() string {
+	if runtime.GOOS == "windows" {
+		localappdata := os.Getenv("LOCALAPPDATA")
+		return filepath.Join(localappdata, "RLBotGUI")
+	}
+
+	home := os.Getenv("HOME")
+	return filepath.Join(home, ".rlbotgui")
+}
+
+func (a *App) DownloadBotpack(url string, installPath string) Result {
+	return Result{false, "Not implemented"}
+}
+
 // NewApp creates a new App application struct
 func NewApp() *App {
 	ip := os.Getenv("RLBOT_SERVER_IP")
@@ -34,18 +49,11 @@ func NewApp() *App {
 	}
 
 	rlbot_address := ip + ":" + port
-	// print the address
-	println("RLBotServer address: " + rlbot_address)
 
 	return &App{
 		rlbot_address,
 	}
 }
-
-// // Greet returns a greeting for the given name
-// func (a *App) Greet(name string) string {
-// 	return fmt.Sprintf("Hello %s, It's show time!", name)
-// }
 
 func recursiveFileSearch(root, pattern string) ([]string, error) {
 	var matches []string

--- a/app.go
+++ b/app.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 
@@ -12,7 +11,7 @@ import (
 
 // App struct
 type App struct {
-	ctx context.Context
+	rlbot_address string
 }
 
 func (a *App) IgnoreMe(
@@ -24,13 +23,23 @@ func (a *App) IgnoreMe(
 
 // NewApp creates a new App application struct
 func NewApp() *App {
-	return &App{}
-}
+	ip := os.Getenv("RLBOT_SERVER_IP")
+	if ip == "" {
+		ip = "127.0.0.1"
+	}
 
-// startup is called when the app starts. The context is saved
-// so we can call the runtime methods
-func (a *App) startup(ctx context.Context) {
-	a.ctx = ctx
+	port := os.Getenv("RLBOT_SERVER_PORT")
+	if port == "" {
+		port = "23234"
+	}
+
+	rlbot_address := ip + ":" + port
+	// print the address
+	println("RLBotServer address: " + rlbot_address)
+
+	return &App{
+		rlbot_address,
+	}
 }
 
 // // Greet returns a greeting for the given name
@@ -85,10 +94,9 @@ type StartMatchOptions struct {
 
 func (a *App) StartMatch(options StartMatchOptions) Result {
 	// TODO: Save this in App struct
-	// TODO: Make dynamic, pull from env var?
-	conn, err := rlbot.Connect("127.0.0.1:23234")
+	conn, err := rlbot.Connect(a.rlbot_address)
 	if err != nil {
-		return Result{false, "Failed to connect to rlbot"}
+		return Result{false, "Failed to connect to RLBotServer at " + a.rlbot_address}
 	}
 
 	var gameMode flat.GameMode
@@ -107,6 +115,8 @@ func (a *App) StartMatch(options StartMatchOptions) Result {
 		gameMode = flat.GameModeHeatseeker
 	case "Gridiron":
 		gameMode = flat.GameModeGridiron
+	case "Knockout":
+		gameMode = flat.GameModeKnockout
 	default:
 		println("No mode chosen, defaulting to soccer")
 		gameMode = flat.GameModeSoccer

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,6 @@
     "@rsbuild/core": "1.0.5",
     "@rsbuild/plugin-svelte": "1.0.5",
     "oxlint": "^0.13.2",
-    "typescript": "^5.7.3"
+    "typescript": "^5.8.2"
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -26,13 +26,13 @@ importers:
         version: 1.0.5
       '@rsbuild/plugin-svelte':
         specifier: 1.0.5
-        version: 1.0.5(@rsbuild/core@1.0.5)(svelte@5.20.5)(typescript@5.7.3)
+        version: 1.0.5(@rsbuild/core@1.0.5)(svelte@5.20.5)(typescript@5.8.2)
       oxlint:
         specifier: ^0.13.2
         version: 0.13.2
       typescript:
-        specifier: ^5.7.3
-        version: 5.7.3
+        specifier: ^5.8.2
+        version: 5.8.2
 
 packages:
 
@@ -337,8 +337,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typescript@5.7.3:
-    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
+  typescript@5.8.2:
+    resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -419,11 +419,11 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  '@rsbuild/plugin-svelte@1.0.5(@rsbuild/core@1.0.5)(svelte@5.20.5)(typescript@5.7.3)':
+  '@rsbuild/plugin-svelte@1.0.5(@rsbuild/core@1.0.5)(svelte@5.20.5)(typescript@5.8.2)':
     dependencies:
       '@rsbuild/core': 1.0.5
       svelte-loader: 3.2.4(svelte@5.20.5)
-      svelte-preprocess: 6.0.3(svelte@5.20.5)(typescript@5.7.3)
+      svelte-preprocess: 6.0.3(svelte@5.20.5)(typescript@5.8.2)
     transitivePeerDependencies:
       - '@babel/core'
       - coffeescript
@@ -579,11 +579,11 @@ snapshots:
       svelte-dev-helper: 1.1.9
       svelte-hmr: 0.14.12(svelte@5.20.5)
 
-  svelte-preprocess@6.0.3(svelte@5.20.5)(typescript@5.7.3):
+  svelte-preprocess@6.0.3(svelte@5.20.5)(typescript@5.8.2):
     dependencies:
       svelte: 5.20.5
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
 
   svelte-writable-derived@3.1.1(svelte@5.20.5):
     dependencies:
@@ -608,6 +608,6 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  typescript@5.7.3: {}
+  typescript@5.8.2: {}
 
   zimmerframe@1.1.2: {}

--- a/frontend/src/components/BotList.svelte
+++ b/frontend/src/components/BotList.svelte
@@ -35,7 +35,7 @@
                     case categories[1][2]:
                         return bot.tags.some((tag) => tag === "memebot");
                     default:
-                        return [];
+                        return true;
                 }
             });
         }
@@ -50,7 +50,7 @@
                     case categories[2][2]:
                         return bot.tags.some((tag) => tag === "goalie");
                     default:
-                        return [];
+                        return true;
                 }
             });
         }

--- a/frontend/src/components/BotList.svelte
+++ b/frontend/src/components/BotList.svelte
@@ -7,7 +7,21 @@
     } from "svelte-dnd-action";
     import defaultIcon from "../assets/rlbot_mono.png";
     import type { DraggablePlayer } from "../index";
-    let { items = [], showHuman = $bindable(true), searchQuery = "" }: { items: DraggablePlayer[], showHuman: boolean, searchQuery: string } = $props();
+    let {
+        items = [],
+        showHuman = $bindable(true),
+        searchQuery = "",
+        selectedTeam = null,
+        bluePlayers = $bindable(),
+        orangePlayers = $bindable(),
+    }: {
+        items: DraggablePlayer[],
+        showHuman: boolean,
+        searchQuery: string,
+        selectedTeam: 'blue' | 'orange' | null,
+        bluePlayers: DraggablePlayer[],
+        orangePlayers: DraggablePlayer[],
+    } = $props();
     const flipDurationMs = 100;
 
     let selectedTags: (string | null)[] = $state([null, null]);
@@ -84,7 +98,6 @@
         if (trigger === TRIGGERS.DRAG_STARTED) {
             const newId = `${id}-${Math.round(Math.random() * 100000)}`;
             const idx = filteredItems.findIndex((item) => item.id === id);
-            console.log(e.detail.items.filter((item: any) => item[SHADOW_ITEM_MARKER_PROPERTY_NAME]).forEach((item: any) => item.id = newId));
             e.detail.items = e.detail.items.filter(
                 (item: any) => !item[SHADOW_ITEM_MARKER_PROPERTY_NAME],
             );
@@ -94,6 +107,19 @@
     }
     function handleDndFinalize(e: any) {
         filteredItems = e.detail.items;
+    }
+
+    function handleBotClick(bot: DraggablePlayer) {
+        const newId = `${bot.id}-${Math.round(Math.random() * 100000)}`;
+        const idx = filteredItems.findIndex((item) => item.id === bot.id);
+        //@ts-ignore
+        filteredItems.splice(idx, 1, { ...filteredItems[idx], id: newId });
+
+        if (selectedTeam === "blue") {
+            bluePlayers = [bot, ...bluePlayers];
+        } else if (selectedTeam === "orange") {
+            orangePlayers = [bot, ...orangePlayers];
+        }
     }
 </script>
 
@@ -124,8 +150,10 @@
     onconsider={handleDndConsider}
     onfinalize={handleDndFinalize}
 >
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
     {#each filteredItems as bot (bot.id)}
-        <div class="bot" animate:flip={{ duration: flipDurationMs }}>
+        <div class="bot" animate:flip={{ duration: flipDurationMs }} onclick={() => handleBotClick(bot)}>
             <img src={bot.icon || defaultIcon} alt="icon" />
             <p>{bot.displayName}</p>
         </div>
@@ -183,6 +211,7 @@
         padding-right: 0.6rem;
         gap: 0.5rem;
         border-radius: 0.2rem;
+        cursor: pointer;
     }
     .bot img {
         height: 2rem;

--- a/frontend/src/components/BotList.svelte
+++ b/frontend/src/components/BotList.svelte
@@ -10,7 +10,7 @@
     let { items = [] }: { items: DraggablePlayer[] } = $props();
     const flipDurationMs = 100;
 
-    let selectedTag = $state("All");
+    let selectedTags: (string | null)[] = $state([null, null]);
     const extraModeTags = ["hoops", "dropshot", "snow-day", "spike-rush", "heatseaker"];
     const categories = [
         ["All"],
@@ -19,40 +19,49 @@
     ];
 
     function filterBots() {
-        switch (selectedTag) {
-            case "Standard":
-                return items.filter((bot) => {
-                    return !bot.tags.some((tag) =>
-                        [...extraModeTags, "memebot", "human"].includes(tag),
-                    );
-                });
-            case "Extra Modes":
-                return items.filter((bot) => {
-                    return bot.tags.some((tag) => extraModeTags.includes(tag));
-                });
-            case "Special bots/scripts":
-                return items.filter((bot) => {
-                    return bot.tags.some((tag) => tag === "memebot");
-                });
-            case "Bots for 1v1":
-                return items.filter((bot) => {
-                    return bot.tags.some((tag) => tag === "1v1");
-                });
-            case "Bots with teamplay":
-                return items.filter((bot) => {
-                    return bot.tags.some((tag) => tag === "teamplay");
-                });
-            case "Goalie bots":
-                return items.filter((bot) => {
-                    return bot.tags.some((tag) => tag === "goalie");
-                });
-            default:
-                return items;
+        let filteredItems = items;
+
+        if (selectedTags[0]) {
+            filteredItems = filteredItems.filter((bot) => {
+                switch (selectedTags[0]) {
+                    case categories[1][0]:
+                        return !bot.tags.some((tag) =>
+                            [...extraModeTags, "memebot", "human"].includes(tag),
+                        );
+                    case categories[1][1]:
+                        return bot.tags.some((tag) => extraModeTags.includes(tag));
+                    case categories[1][2]:
+                        return bot.tags.some((tag) => tag === "memebot");
+                    default:
+                        return [];
+                }
+            });
         }
+
+        if (selectedTags[1]) {
+            filteredItems = filteredItems.filter((bot) => {
+                switch (selectedTags[1]) {
+                    case categories[2][0]:
+                        return bot.tags.some((tag) => tag === "1v1");
+                    case categories[2][1]:
+                        return bot.tags.some((tag) => tag === "teamplay");
+                    case categories[2][2]:
+                        return bot.tags.some((tag) => tag === "goalie");
+                    default:
+                        return [];
+                }
+            });
+        }
+
+        return filteredItems;
     }
 
-    function handleTagClick(tag: string) {
-        selectedTag = tag;
+    function handleTagClick(tag: string, groupIndex: number) {
+        if (groupIndex === 0) {
+            selectedTags = [null, null];
+        } else {
+            selectedTags[groupIndex-1] = selectedTags[groupIndex-1] === tag ? null : tag;
+        }
     }
 
     let shouldIgnoreDndEvents = false;
@@ -84,10 +93,13 @@
 </script>
 
 <div class="tag-buttons">
-    {#each categories as tagGroup}
+    {#each categories as tagGroup, groupIndex}
         <div class="tag-group">
             {#each tagGroup as tag}
-                <button onclick={() => handleTagClick(tag)} class:selected={selectedTag === tag}>
+                <button
+                    onclick={() => handleTagClick(tag, groupIndex)}
+                    class:selected={tag === categories[0][0] ? selectedTags.every(t => t == null) : selectedTags[groupIndex-1] === tag}
+                >
                     {tag}
                 </button>
             {/each}

--- a/frontend/src/components/BotList.svelte
+++ b/frontend/src/components/BotList.svelte
@@ -7,7 +7,7 @@
     } from "svelte-dnd-action";
     import defaultIcon from "../assets/rlbot_mono.png";
     import type { DraggablePlayer } from "../index";
-    let { items = [] }: { items: DraggablePlayer[] } = $props();
+    let { items = [], showHuman = $bindable(true) }: { items: DraggablePlayer[], showHuman: boolean } = $props();
     const flipDurationMs = 100;
 
     let selectedTags: (string | null)[] = $state([null, null]);
@@ -20,11 +20,11 @@
 
     let filteredItems: DraggablePlayer[] = $state([]);
     $effect(() => {
-        filteredItems = filterBots(selectedTag);
+        filteredItems = filterBots(selectedTags, showHuman);
     });
 
-    function filterBots(filterTags: (string | null)[]) {
-        let filtered = [...items];
+    function filterBots(filterTags: (string | null)[], showHuman: boolean) {
+        let filtered = items.slice(1);
 
         if (filterTags[0]) {
             filtered = filtered.filter((bot) => {
@@ -56,6 +56,10 @@
                         return true;
                 }
             });
+        }
+
+        if (showHuman) {
+            filtered = [items[0], ...filtered];
         }
 
         return filtered;

--- a/frontend/src/components/BotList.svelte
+++ b/frontend/src/components/BotList.svelte
@@ -18,12 +18,14 @@
         ["Bots for 1v1", "Bots with teamplay", "Goalie bots"]
     ];
 
-    function filterBots() {
-        let filteredItems = items;
+    let filteredItems = $derived(filterBots(selectedTags))
 
-        if (selectedTags[0]) {
-            filteredItems = filteredItems.filter((bot) => {
-                switch (selectedTags[0]) {
+    function filterBots(filterTags: (string | null)[]) {
+        let filtered = [...items];
+
+        if (filterTags[0]) {
+            filtered = filtered.filter((bot) => {
+                switch (filterTags[0]) {
                     case categories[1][0]:
                         return !bot.tags.some((tag) =>
                             [...extraModeTags, "memebot", "human"].includes(tag),
@@ -38,9 +40,9 @@
             });
         }
 
-        if (selectedTags[1]) {
-            filteredItems = filteredItems.filter((bot) => {
-                switch (selectedTags[1]) {
+        if (filterTags[1]) {
+            filtered = filtered.filter((bot) => {
+                switch (filterTags[1]) {
                     case categories[2][0]:
                         return bot.tags.some((tag) => tag === "1v1");
                     case categories[2][1]:
@@ -53,32 +55,8 @@
             });
         }
 
-        return filteredItems;
+        return filtered;
     }
-//     let filteredItems = $derived(filterBots(selectedTag))
-
-//     function filterBots(filterTag: string) {
-//         return items.filter((bot) => {
-//             switch (filterTag) {
-//                 case "Standard":
-//                     return !bot.tags.some((tag) =>
-//                         [...extraModeTags, "memebot", "human"].includes(tag),
-//                     );
-//                 case "Extra Modes":
-//                     return bot.tags.some((tag) => extraModeTags.includes(tag));
-//                 case "Special bots/scripts":
-//                     return bot.tags.some((tag) => tag === "memebot");
-//                 case "Bots for 1v1":
-//                     return bot.tags.some((tag) => tag === "1v1");
-//                 case "Bots with teamplay":
-//                     return bot.tags.some((tag) => tag === "teamplay");
-//                 case "Goalie bots":
-//                     return bot.tags.some((tag) => tag === "goalie");
-//                 default:
-//                     return items;
-//             }
-//         });
-//     }
 
     function handleTagClick(tag: string, groupIndex: number) {
         if (groupIndex === 0) {

--- a/frontend/src/components/BotList.svelte
+++ b/frontend/src/components/BotList.svelte
@@ -7,7 +7,7 @@
     } from "svelte-dnd-action";
     import defaultIcon from "../assets/rlbot_mono.png";
     import type { DraggablePlayer } from "../index";
-    let { items = [], showHuman = $bindable(true) }: { items: DraggablePlayer[], showHuman: boolean } = $props();
+    let { items = [], showHuman = $bindable(true), searchQuery = "" }: { items: DraggablePlayer[], showHuman: boolean, searchQuery: string } = $props();
     const flipDurationMs = 100;
 
     let selectedTags: (string | null)[] = $state([null, null]);
@@ -20,10 +20,10 @@
 
     let filteredItems: DraggablePlayer[] = $state([]);
     $effect(() => {
-        filteredItems = filterBots(selectedTags, showHuman);
+        filteredItems = filterBots(selectedTags, showHuman, searchQuery);
     });
 
-    function filterBots(filterTags: (string | null)[], showHuman: boolean) {
+    function filterBots(filterTags: (string | null)[], showHuman: boolean, searchQuery: string) {
         let filtered = items.slice(1);
 
         if (filterTags[0]) {
@@ -60,6 +60,12 @@
 
         if (showHuman) {
             filtered = [items[0], ...filtered];
+        }
+
+        if (searchQuery) {
+            filtered = filtered.filter((bot) =>
+                bot.displayName.toLowerCase().includes(searchQuery.toLowerCase())
+            );
         }
 
         return filtered;

--- a/frontend/src/components/MatchSettings/Main.svelte
+++ b/frontend/src/components/MatchSettings/Main.svelte
@@ -4,6 +4,7 @@
     import { MAPS_NON_STANDARD, MAPS_STANDARD } from "../../arena-names";
     import { mutators as mutatorOptions } from "./rlmutators";
     import LauncherSelector from "../LauncherSelector.svelte";
+    import { gamemodes } from "./rlmodes";
 
     let {
         map = $bindable(),
@@ -29,6 +30,44 @@
     function cleanCase(toClean: string) {
         toClean = toClean.replaceAll("_", " ").replace(" option", "")
         return toClean.charAt(0).toUpperCase() + toClean.slice(1);
+    }
+
+    function resetMutators() {
+        for (let key of Object.keys(mutators)) {
+            mutators[key] = 0;
+        }
+    }
+
+    function setPreset(preset: string) {
+        if (preset === "") {
+            mode = mutatorOptions.game_mode[0];
+            map = MAPS_STANDARD["DFH Stadium"];
+            randomizeMap = true;
+            resetMutators();
+            return;
+        }
+
+        const presetData = gamemodes[preset];
+        if (!presetData) return;
+
+        if (presetData.match["game_mode"] !== undefined) {
+            mode = presetData.match["game_mode"];
+        }
+
+        if (presetData.match["game_map_upk"] !== undefined) {
+            map = presetData.match["game_map_upk"];
+            randomizeMap = false;
+        } else {
+            randomizeMap = true;
+        }
+
+        for (let key of filteredMutatorOptions) {
+            if (presetData.mutators[key] !== undefined) {
+                mutators[key] = mutatorOptions[key].indexOf(presetData.mutators[key]);
+            } else {
+                mutators[key] = 0;
+            }
+        }
     }
 
     const ALL_MAPS = {...MAPS_STANDARD, ...MAPS_NON_STANDARD};
@@ -102,16 +141,24 @@
                 </select>
             </div>
         {/each}
+        <div></div>
+        <div class="mutator">
+            <label for="gamemode"><b>Presets</b></label>
+            <select name="gamemode" id="gamemode" onchange={(e) => {
+                // @ts-ignore
+                setPreset(e.target.value)
+            }}>
+                {#each ["", ...Object.keys(gamemodes)] as gamemode}
+                    <option value={gamemode}>{gamemode}</option>
+                {/each}
+            </select>
+        </div>
     </div>
     <div class="bottomButtons">
         <p>Settings are saved automatically</p>
         <button
             class="mutatorResetButton"
-            onclick={() => {
-                for (let key of Object.keys(mutators)) {
-                    mutators[key] = 0;
-                }
-            }}>Reset</button
+            onclick={resetMutators}>Reset</button
         >
     </div>
 </Modal>

--- a/frontend/src/components/MatchSettings/Main.svelte
+++ b/frontend/src/components/MatchSettings/Main.svelte
@@ -15,7 +15,10 @@
     } = $props();
     let showExtraOptions = $state(false);
     let showMutators = $state(false);
-    let randomizeMap = $state(false);
+    let randomizeMap = $state(localStorage.getItem("MS_RANDOMIZE_MAP") === "true");
+    $effect(() => {
+        localStorage.setItem("MS_RANDOMIZE_MAP", randomizeMap.toString());
+    });
 
     const existingMatchBehaviors: { [n: string]: number } = {
         "Restart if different": 0,

--- a/frontend/src/components/MatchSettings/rlmodes.ts
+++ b/frontend/src/components/MatchSettings/rlmodes.ts
@@ -1,0 +1,150 @@
+import { mutators } from "./rlmutators"
+
+export const gamemodes: { [x: string]: { match: { [x: string]: string }, mutators: { [x: string]: string } } } = {
+  "Heatseeker Ricochet": {
+    match: {
+      game_mode: mutators.game_mode[5],
+      game_map_upk: "Labs_PillarGlass_P",
+    },
+    mutators: {},
+  },
+  "Gotham City Rumble": {
+    match: {
+      game_mode: mutators.game_mode[0],
+      game_map_upk: "Park_Bman_P",
+    },
+    mutators: {
+      rumble_option: mutators.rumble_option[10],
+    },
+  },
+  "Speed Demon": {
+    match: {
+      game_mode: mutators.game_mode[0],
+    },
+    mutators: {
+      boost_amount_option: mutators.boost_amount_option[1],
+      boost_strength_option: mutators.boost_strength_option[2],
+      ball_max_speed_option: mutators.ball_max_speed_option[3],
+      ball_bounciness_option: mutators.ball_bounciness_option[1],
+      ball_size_option: mutators.ball_size_option[3],
+      respawn_time_option: mutators.respawn_time_option[2],
+      demolish_option: mutators.demolish_option[3],
+    },
+  },
+  "Ghost Hunt": {
+    match: {
+      game_mode: mutators.game_mode[0],
+      game_map_upk: "Haunted_TrainStation_P",
+    },
+    mutators: {
+      ball_type_option: mutators.ball_type_option[6],
+      rumble_option: mutators.rumble_option[8],
+      game_event_option: mutators.game_event_option[1],
+      audio_option: mutators.audio_option[1],
+    },
+  },
+  "Dropshot Rumble": {
+    match: {
+      game_mode: mutators.game_mode[2],
+      game_map_upk: "ShatterShot_P",
+    },
+    mutators: {
+      rumble_option: mutators.rumble_option[1],
+    },
+  },
+  "Nike Fc Showdown": {
+    match: {
+      game_mode: mutators.game_mode[0],
+      game_map_upk: "swoosh_p",
+    },
+    mutators: {
+      ball_max_speed_option: mutators.ball_max_speed_option[2],
+      ball_weight_option: mutators.ball_weight_option[6],
+      ball_bounciness_option: mutators.ball_bounciness_option[4],
+      ball_type_option: mutators.ball_type_option[7],
+    },
+  },
+  "Tactical Rumble": {
+    match: {
+      game_mode: mutators.game_mode[4],
+    },
+    mutators: {
+      rumble_option: mutators.rumble_option[9],
+    },
+  },
+  "Gforce Frenzy": {
+    match: {
+      game_mode: mutators.game_mode[0],
+    },
+    mutators: {
+      boost_amount_option: mutators.boost_amount_option[1],
+      boost_strength_option: mutators.boost_strength_option[3],
+      gravity_option: mutators.gravity_option[1],
+    },
+  },
+  "Spike Rush": {
+    match: {
+      game_mode: mutators.game_mode[0],
+      game_map_upk: "ThrowbackStadium_P",
+    },
+    mutators: {
+      rumble_option: mutators.rumble_option[7],
+      respawn_time_option: mutators.respawn_time_option[2],
+      game_event_option: mutators.game_event_option[2],
+    },
+  },
+  "Spring Loaded": {
+    match: {},
+    mutators: {
+      rumble_option: mutators.rumble_option[5],
+    },
+  },
+  "Spooky Cube": {
+    match: {
+      game_mode: mutators.game_mode[0],
+    },
+    mutators: {
+      ball_max_speed_option: mutators.ball_max_speed_option[3],
+      ball_type_option: mutators.ball_type_option[8],
+      ball_weight_option: mutators.ball_weight_option[1],
+      ball_bounciness_option: mutators.ball_bounciness_option[2],
+      boost_amount_option: mutators.boost_amount_option[1],
+    },
+  },
+  "Beach Ball": {
+    match: {
+      game_mode: mutators.game_mode[0],
+    },
+    mutators: {
+      ball_max_speed_option: mutators.ball_max_speed_option[2],
+      ball_type_option: mutators.ball_type_option[4],
+      ball_weight_option: mutators.ball_weight_option[5],
+      ball_size_option: mutators.ball_size_option[2],
+      ball_bounciness_option: mutators.ball_bounciness_option[2],
+    },
+  },
+  "Super Cube": {
+    match: {
+      game_mode: mutators.game_mode[0],
+    },
+    mutators: {
+      ball_max_speed_option: mutators.ball_max_speed_option[3],
+      ball_type_option: mutators.ball_type_option[1],
+      ball_weight_option: mutators.ball_weight_option[1],
+      ball_bounciness_option: mutators.ball_bounciness_option[2],
+      boost_amount_option: mutators.boost_amount_option[1],
+    },
+  },
+  "Boomer Ball": {
+    match: {
+      game_mode: mutators.game_mode[0],
+    },
+    mutators: {
+      boost_amount_option: mutators.boost_amount_option[1],
+      boost_strength_option: mutators.boost_strength_option[1],
+      ball_max_speed_option: mutators.ball_max_speed_option[3],
+      ball_bounciness_option: mutators.ball_bounciness_option[2],
+      ball_weight_option: mutators.ball_weight_option[3],
+    },
+  },
+}

--- a/frontend/src/components/MatchSettings/rlmutators.ts
+++ b/frontend/src/components/MatchSettings/rlmutators.ts
@@ -61,7 +61,7 @@ export const mutators: { [x: string]: string[] } = {
     "Super High",
     "Lowish",
   ],
-  boost_option: [
+  boost_amount_option: [
     "Default",
     "Unlimited",
     "Slow Recharge",

--- a/frontend/src/components/Modal.svelte
+++ b/frontend/src/components/Modal.svelte
@@ -24,6 +24,7 @@
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class={"modalContainer " + (visible ? "" : "hidden")} bind:this={wrap} onclick={handleOuter} onmousedown={handleMouseDown}>
+    <!-- TODO: Revert the min width/height stuff as it can be done in the child elements -->
     <div class="modal" style={`min-width: ${minWidth}; min-height: ${minHeight};`}>
         <header>
             <h2>{title}</h2>

--- a/frontend/src/components/Modal.svelte
+++ b/frontend/src/components/Modal.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
     import close from "../assets/close.svg";
-    let { title = "Modal", visible = $bindable(true), children } = $props();
+    let {
+        title = "Modal",
+        visible = $bindable(true),
+        children,
+        minWidth = "20vw",
+        minHeight = "20vh"
+    } = $props();
 
     let background: EventTarget;
     let wrap: EventTarget;
@@ -15,7 +21,7 @@
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class={visible ? "" : "hidden"} bind:this={background} onclick={handleOuter}>
     <div class="modalContainer" bind:this={wrap}>
-        <div class="modal">
+        <div class="modal" style={`min-width: ${minWidth}; min-height: ${minHeight};`}>
             <header>
                 <h2>{title}</h2>
                 <button
@@ -55,8 +61,6 @@
         background-color: var(--background);
         padding: 0.2rem;
         border-radius: 0.6rem;
-        min-width: 20vw;
-        min-height: 20vh;
     }
     header {
         padding: 0.2rem;
@@ -64,6 +68,7 @@
         border-bottom: 1px solid var(--background-alt);
         display: flex;
         justify-content: space-between;
+        align-items: center;
     }
     header button {
         padding: 0px;

--- a/frontend/src/components/PathsViewer.svelte
+++ b/frontend/src/components/PathsViewer.svelte
@@ -136,7 +136,7 @@
             </label>
         </div>
         {#if selectedBotpackType === "custom"}
-            <input type="text" placeholder="https://github.com/owner/repo" bind:value={customRepo} />
+            <input type="text" placeholder="owner/repo" bind:value={customRepo} />
         {/if}
         <div class="button-row">
             <button onclick={confirmAddBotpack}>Confirm</button>

--- a/frontend/src/components/PathsViewer.svelte
+++ b/frontend/src/components/PathsViewer.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+    import { App } from "../../bindings/gui";
+    import Modal from "./Modal.svelte";
+    import closeIcon from "../assets/close.svg";
+
+    let { visible = $bindable(false), paths = $bindable([]) } = $props();
+
+    function removePath(index: number) {
+        paths.splice(index, 1);
+        paths = paths;
+    }
+</script>
+
+<Modal title="Manage Paths" bind:visible={visible} minWidth="70vw" minHeight="50vh">
+    <div class="paths">
+        <div class="button-row">
+            <button
+                class="full-width"
+                onclick={async () => {
+                    let result = await App.PickFolder();
+                    console.log("PickFolder returned:", result);
+                    if (result != "") {
+                        paths = [...paths, result];
+                    }
+                }}>Add folder</button>
+            <button class="full-width" onclick={alert.bind(null, "TODO: not implemented yet")}>Add Botpack</button>
+            <button class="full-width" onclick={alert.bind(null, "TODO: not implemented yet")}>Add File</button>
+        </div>
+
+        {#each paths as path, i}
+            <div class="path">
+                <pre>{path}</pre>
+                <button class="close" onclick={() => removePath(i)}>
+                    <img src={closeIcon} alt="X" />
+                </button>
+            </div>
+        {/each}
+    </div>
+</Modal>
+
+<style>
+    .paths {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+    }
+    .button-row {
+        display: flex;
+        gap: 1rem;
+    }
+    .full-width {
+        flex: 1;
+    }
+    .path {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        justify-content: space-between;
+    }
+    .path pre {
+        font-size: 1rem;
+        margin: 0px;
+    }
+    .path button {
+        padding: 0px;
+    }
+    .path button img {
+        filter: invert();
+    }
+</style>

--- a/frontend/src/components/PathsViewer.svelte
+++ b/frontend/src/components/PathsViewer.svelte
@@ -105,6 +105,7 @@
 <Modal title="Manage Paths" bind:visible={visible} minWidth="70vw" minHeight="50vh">
     <div class="paths">
         <div class="button-row">
+            <!-- TODO: this class is not needed -->
             <button class="full-width" onclick={addFolder}>Add folder</button>
             <button class="full-width" onclick={openAddBotpackModal}>Add Botpack</button>
             <button class="full-width" onclick={alert.bind(null, "TODO: not implemented yet")}>Add File</button>

--- a/frontend/src/components/PathsViewer.svelte
+++ b/frontend/src/components/PathsViewer.svelte
@@ -2,27 +2,112 @@
     import { App } from "../../bindings/gui";
     import Modal from "./Modal.svelte";
     import closeIcon from "../assets/close.svg";
+    import toast from "svelte-5-french-toast";
+
+    const GITHUB_URL = "https://github.com/";
+    const OFFICIAL_BOTPACK_URL = GITHUB_URL + "VirxEC/botpack-test";
 
     let { visible = $bindable(false), paths = $bindable([]) } = $props();
 
+    let botpacks: { url: string, installPath: string }[] = $state(
+        JSON.parse(localStorage.getItem("BOTPACKS") || "[]"),
+    );
+
+    $effect(() => {
+        localStorage.setItem("BOTPACKS", JSON.stringify(botpacks));
+    });
+
+    let addBotpackVisible = $state(false);
+    let selectedBotpackType = $state("official");
+    let customURL = $state("");
+    let installPath = $state("");
+
+    function setDefaultPath() {
+        App.GetDefaultPath().then((result) => {
+            installPath = result + "/RLBotPack";
+        });
+    }
+
+    setDefaultPath();
+
     function removePath(index: number) {
         paths.splice(index, 1);
+    }
+
+    function removeBotpack(index: number) {
+        botpacks.splice(index, 1);
+    }
+
+    function openAddBotpackModal() {
+        visible = false;
+        addBotpackVisible = true;
+    }
+
+    function closeAddBotpackModal() {
+        addBotpackVisible = false;
+        visible = true;
+        selectedBotpackType = "official";
+        customURL = "";
+        setDefaultPath();
+    }
+
+    function addFolder() {
+        App.PickFolder().then((result) => {
+            if (result) {
+                paths = [...paths, result];
+            }
+        });
+    }
+
+    function confirmAddBotpack() {
+        if (!installPath) {
+            toast.error("Install path cannot be blank");
+            return;
+        }
+    
+        let url = OFFICIAL_BOTPACK_URL;
+        if (selectedBotpackType === "custom") {
+            if (!customURL) {
+                toast.error("URL cannot be blank");
+                return;
+            }
+
+            if (!customURL.startsWith("https://github.com/")) {
+                toast.error("Custom URL must start with 'https://github.com/'");
+                return;
+            }
+
+            url = customURL;
+        }
+
+        if (botpacks.some((x) => x.url === url)) {
+            toast.error("Botpack already added");
+            return;
+        }
+
+        if (botpacks.some((x) => x.installPath === installPath)) {
+            toast.error("Install path already in use");
+            return;
+        }
+
+        App.DownloadBotpack(url, installPath)
+            .then((result) => {
+                if (!result.success) {
+                    toast.error("Failed to download botpack: " + result.message);
+                    return;
+                }
+                    
+                botpacks = [...botpacks, { installPath, url }];
+                closeAddBotpackModal();
+            })
     }
 </script>
 
 <Modal title="Manage Paths" bind:visible={visible} minWidth="70vw" minHeight="50vh">
     <div class="paths">
         <div class="button-row">
-            <button
-                class="full-width"
-                onclick={async () => {
-                    let result = await App.PickFolder();
-                    console.log("PickFolder returned:", result);
-                    if (result != "") {
-                        paths = [...paths, result];
-                    }
-                }}>Add folder</button>
-            <button class="full-width" onclick={alert.bind(null, "TODO: not implemented yet")}>Add Botpack</button>
+            <button class="full-width" onclick={addFolder}>Add folder</button>
+            <button class="full-width" onclick={openAddBotpackModal}>Add Botpack</button>
             <button class="full-width" onclick={alert.bind(null, "TODO: not implemented yet")}>Add File</button>
         </div>
 
@@ -34,6 +119,39 @@
                 </button>
             </div>
         {/each}
+
+        {#each botpacks as botpack, i}
+            <div class="path">
+                <pre>{botpack.url} @ {botpack.installPath}</pre>
+                <button class="close" onclick={() => removeBotpack(i)}>
+                    <img src={closeIcon} alt="X" />
+                </button>
+            </div>
+        {/each}
+    </div>
+</Modal>
+
+<Modal title="Add Botpack" bind:visible={addBotpackVisible} minWidth="50vw">
+    <div class="add-botpack">
+        <label for="path">Install path</label>
+        <input type="text" id="path" placeholder="Enter install path" bind:value={installPath} />
+        <div class="radio-group">
+            <label>
+                <input type="radio" name="botpackType" value="official" bind:group={selectedBotpackType} />
+                Official RLBotPack
+            </label>
+            <label>
+                <input type="radio" name="botpackType" value="custom" bind:group={selectedBotpackType} />
+                Custom
+            </label>
+        </div>
+        {#if selectedBotpackType === "custom"}
+            <input type="text" placeholder="https://github.com/owner/repo" bind:value={customURL} />
+        {/if}
+        <div class="button-row">
+            <button onclick={confirmAddBotpack}>Confirm</button>
+            <button onclick={closeAddBotpackModal}>Cancel</button>
+        </div>
     </div>
 </Modal>
 
@@ -65,5 +183,25 @@
     }
     .path button img {
         filter: invert();
+    }
+    .add-botpack {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+    }
+    .radio-group {
+        flex-direction: column;
+        display: flex;
+        gap: 1rem;
+    }
+    .radio-group label {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+    }
+    .button-row {
+        display: flex;
+        gap: 1rem;
+        justify-content: flex-end;
     }
 </style>

--- a/frontend/src/components/PathsViewer.svelte
+++ b/frontend/src/components/PathsViewer.svelte
@@ -52,7 +52,7 @@
                     return;
                 }
 
-                paths = [...paths, { installPath: result, repo: null, tagName: null }];
+                paths.push({ installPath: result, repo: null, tagName: null });
             }
         });
     }
@@ -93,7 +93,7 @@
             .then((tagName) => {
                 toast.success("Botpack downloaded successfully!", {id});
 
-                paths = [...paths, { installPath, repo, tagName }];
+                paths.push({ installPath, repo, tagName });
                 closeAddBotpackModal();
             })
             .catch((err) => {

--- a/frontend/src/components/PathsViewer.svelte
+++ b/frontend/src/components/PathsViewer.svelte
@@ -7,7 +7,6 @@
 
     function removePath(index: number) {
         paths.splice(index, 1);
-        paths = paths;
     }
 </script>
 

--- a/frontend/src/components/Teams/Main.svelte
+++ b/frontend/src/components/Teams/Main.svelte
@@ -68,8 +68,10 @@
         display: flex;
         color: white;
     }
-    header.blue {
+    header {
         border: 2px solid;
+    }
+    header.blue {
         border-color: #0054a6;
         background-color: #0054a6;
     }

--- a/frontend/src/components/Teams/Main.svelte
+++ b/frontend/src/components/Teams/Main.svelte
@@ -35,6 +35,7 @@
     .teams {
         display: flex;
         gap: 1rem;
+        height: 100%;
     }
     .teams > .team {
         flex: 1;

--- a/frontend/src/components/Teams/Main.svelte
+++ b/frontend/src/components/Teams/Main.svelte
@@ -49,7 +49,7 @@
         height: 100%;
     }
     .teams > .team {
-        flex: 1;
+        flex: 1 0 auto; /* Prevents the team from growing before its child */
         padding: 0px 0;
         /* Nice transparent blur */
         background-color: rgba(0, 0, 0, 0.7);
@@ -59,6 +59,7 @@
         flex-direction: column;
         border: 2px solid transparent;
         border-radius: 0.6rem 0.6rem 0px 0px;
+        max-height: 100%; /* Ensures the team does not grow beyond its container */
     }
     .teams > .team > header {
         border-radius: 0.4rem 0.4rem 0px 0px;

--- a/frontend/src/components/Teams/Main.svelte
+++ b/frontend/src/components/Teams/Main.svelte
@@ -4,11 +4,22 @@
     let {
         bluePlayers = $bindable(),
         orangePlayers = $bindable(),
-    }: { bluePlayers: any[]; orangePlayers: any[] } = $props();
+        selectedTeam = $bindable(null),
+    }: { bluePlayers: any[]; orangePlayers: any[], selectedTeam: 'blue' | 'orange' | null } = $props();
+
+    function toggleTeam(team: 'blue' | 'orange') {
+        if (selectedTeam === team) {
+            selectedTeam = null;
+        } else {
+            selectedTeam = team;
+        }
+    }
 </script>
 
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="teams">
-    <div class="team box">
+    <div class="team box blue" onclick={() => toggleTeam('blue')} class:selected={selectedTeam === 'blue'}>
         <header class="blue">
             <h3>Blue team</h3>
             <div style="flex: 1;"></div>
@@ -16,7 +27,7 @@
         </header>
         <TeamBotList bind:items={bluePlayers} />
     </div>
-    <div class="team box">
+    <div class="team box orange" onclick={() => toggleTeam('orange')} class:selected={selectedTeam === 'orange'}>
         <header class="orange">
             <h3>Orange team</h3>
             <div style="flex: 1;"></div>
@@ -46,6 +57,8 @@
         backdrop-filter: blur(10px);
         display: flex;
         flex-direction: column;
+        border: 2px solid transparent;
+        border-radius: 0.6rem 0.6rem 0px 0px;
     }
     .teams > .team > header {
         border-radius: 0.4rem 0.4rem 0px 0px;
@@ -55,12 +68,24 @@
         color: white;
     }
     header.blue {
+        border: 2px solid;
+        border-color: #0054a6;
         background-color: #0054a6;
     }
     header.orange {
+        border-color: #f26522;
         background-color: #f26522;
     }
     .dimmed {
         color: #ffffffcc;
+    }
+    .team.selected {
+        border: 2px solid;
+    }
+    .team.selected.blue {
+        border-color: #0054a6;
+    }
+    .team.selected.orange {
+        border-color: #f26522;
     }
 </style>

--- a/frontend/src/components/Teams/TeamBotList.svelte
+++ b/frontend/src/components/Teams/TeamBotList.svelte
@@ -34,8 +34,10 @@
         onconsider={handleSort}
         onfinalize={handleSort}
     >
+        <!-- svelte-ignore a11y_click_events_have_key_events -->
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
         {#each items as bot (bot.id)}
-            <div class="bot" animate:flip={{ duration: flipDurationMs }}>
+            <div class="bot" animate:flip={{ duration: flipDurationMs }} onclick={e => e.stopPropagation()}>
                 <img src={bot?.icon || defaultIcon} alt="icon" />
                 <p>{bot?.displayName}</p>
                 <div style="flex: 1;"></div>
@@ -55,7 +57,6 @@
     .teamBotList {
         padding: 0.6rem;
         overflow: auto;
-        height: 100%;
         min-height: 4rem;
         display: flex;
         flex-direction: column;
@@ -70,6 +71,7 @@
         flex-direction: column;
         gap: 0.5rem;
         min-height: 100%;
+        overflow-y: auto;
     }
     .bot {
         display: flex;

--- a/frontend/src/components/Teams/TeamBotList.svelte
+++ b/frontend/src/components/Teams/TeamBotList.svelte
@@ -57,6 +57,7 @@
     .teamBotList {
         padding: 0.6rem;
         overflow: auto;
+        height: 100%;
         min-height: 4rem;
         display: flex;
         flex-direction: column;

--- a/frontend/src/components/Teams/TeamBotList.svelte
+++ b/frontend/src/components/Teams/TeamBotList.svelte
@@ -37,6 +37,7 @@
         <!-- svelte-ignore a11y_click_events_have_key_events -->
         <!-- svelte-ignore a11y_no_static_element_interactions -->
         {#each items as bot (bot.id)}
+            <!-- TODO: maybe remove stopPropagation and instead require a click on the team header -->
             <div class="bot" animate:flip={{ duration: flipDurationMs }} onclick={e => e.stopPropagation()}>
                 <img src={bot?.icon || defaultIcon} alt="icon" />
                 <p>{bot?.displayName}</p>

--- a/frontend/src/pages/Home.svelte
+++ b/frontend/src/pages/Home.svelte
@@ -156,6 +156,12 @@
             });
         }
     }
+
+    let searchQuery = $state("");
+
+    function handleSearch(event: Event) {
+        searchQuery = (event.target as HTMLInputElement).value;
+    }
 </script>
 
 <div class="page" style={`background-image: url("${backgroundImage}")`}>
@@ -173,9 +179,9 @@
                 >
             {/if}
             <div style="flex:1"></div>
-            <input type="text" class="botSearch" placeholder="Search..." />
+            <input type="text" class="botSearch" placeholder="Search..." oninput={handleSearch}/>
         </header>
-        <BotList bind:showHuman items={players} />
+        <BotList bind:showHuman items={players} searchQuery={searchQuery} />
     </div>
 
     <div class="teams"><Teams bind:bluePlayers bind:orangePlayers /></div>

--- a/frontend/src/pages/Home.svelte
+++ b/frontend/src/pages/Home.svelte
@@ -8,7 +8,6 @@
     /** @import * from '../../bindings/gui' */
     import toast from "svelte-5-french-toast";
     import arenaImages from "../arena-images";
-    import closeIcon from "../assets/close.svg";
     import reloadIcon from "../assets/reload.svg";
     import BotList from "../components/BotList.svelte";
     // @ts-ignore
@@ -20,7 +19,6 @@
     import { mapStore } from "../settings";
     import { MAPS_STANDARD } from "../arena-names";
     import PathsViewer from "../components/PathsViewer.svelte";
-    import { alertToScreenReader } from "svelte-dnd-action";
 
     const backgroundImage =
         arenaImages[Math.floor(Math.random() * arenaImages.length)];
@@ -66,6 +64,10 @@
 
     let bluePlayers: DraggablePlayer[] = $state([]);
     let orangePlayers: DraggablePlayer[] = $state([]);
+    let showHuman = $state(true);
+    $effect(() => {
+        showHuman = !(bluePlayers.some((x) => x.tags.includes("human")) || orangePlayers.some((x) => x.tags.includes("human")));
+    });
 
     let mode = $state(localStorage.getItem("MS_MODE") || "Soccer");
     $effect(() => {
@@ -173,7 +175,7 @@
             <div style="flex:1"></div>
             <input type="text" class="botSearch" placeholder="Search..." />
         </header>
-        <BotList items={players} />
+        <BotList bind:showHuman items={players} />
     </div>
 
     <div><Teams bind:bluePlayers bind:orangePlayers /></div>

--- a/frontend/src/pages/Home.svelte
+++ b/frontend/src/pages/Home.svelte
@@ -19,12 +19,11 @@
     import { BASE_PLAYERS } from "../base-players";
     import { mapStore } from "../settings";
     import { MAPS_STANDARD } from "../arena-names";
+    import PathsViewer from "../components/PathsViewer.svelte";
+    import { alertToScreenReader } from "svelte-dnd-action";
 
     const backgroundImage =
         arenaImages[Math.floor(Math.random() * arenaImages.length)];
-    // const backgroundImage = arenaImages.find((x) =>
-    //     x.includes("Mannfield_Stormy"),
-    // );
 
     let paths = $state(
         JSON.parse(window.localStorage.getItem("BOT_SEARCH_PATHS") || "[]"),
@@ -34,6 +33,8 @@
 
     let loadingPlayers = $state(false);
     let latestBotUpdateTime = null;
+    let showPathsViewer = $state(false);
+
     async function updateBots() {
         loadingPlayers = true;
         let internalUpdateTime = new Date();
@@ -160,33 +161,7 @@
         <header>
             <h1>Bots</h1>
             <div class="dropdown">
-                <button>Add/Remove</button>
-                <div class="dropmenu">
-                    {#each paths as path, i}
-                        <div class="path">
-                            <pre>{path}</pre>
-                            <button
-                                class="close"
-                                onclick={() => {
-                                    paths.splice(i, 1);
-                                    // makes reactivity work
-                                    paths = paths;
-                                }}
-                            >
-                                <img src={closeIcon} alt="X" />
-                            </button>
-                        </div>
-                    {/each}
-                    <button
-                        onclick={async () => {
-                            let result = await App.PickFolder();
-                            console.log("PickFolder returned:", result);
-                            if (result != "") {
-                                paths = [...paths, result];
-                            }
-                        }}>Add folder</button
-                    >
-                </div>
+                <button onclick={() => { showPathsViewer = true }}>Add/Remove</button>
             </div>
             {#if loadingPlayers}
                 <h3>Searching...</h3>
@@ -214,6 +189,8 @@
         />
     </div>
 </div>
+
+<PathsViewer bind:visible={showPathsViewer} bind:paths={paths} />
 
 <style>
     .page {
@@ -253,22 +230,6 @@
         padding: 0px;
     }
     .reloadButton img {
-        filter: invert();
-    }
-    .path {
-        display: flex;
-        align-items: center;
-        gap: 1rem;
-        justify-content: space-between;
-    }
-    .path pre {
-        font-size: 1rem;
-        margin: 0px;
-    }
-    .path button {
-        padding: 0px;
-    }
-    .path button img {
         filter: invert();
     }
 </style>

--- a/frontend/src/pages/Home.svelte
+++ b/frontend/src/pages/Home.svelte
@@ -178,7 +178,7 @@
         <BotList bind:showHuman items={players} />
     </div>
 
-    <div><Teams bind:bluePlayers bind:orangePlayers /></div>
+    <div class="teams"><Teams bind:bluePlayers bind:orangePlayers /></div>
 
     <div class="box">
         <MatchSettings
@@ -221,6 +221,9 @@
     }
     .availableBots {
         padding-bottom: 0.6rem;
+        flex-grow: 2;
+        display: flex;
+        flex-direction: column;
     }
     .availableBots header {
         display: flex;
@@ -233,5 +236,10 @@
     }
     .reloadButton img {
         filter: invert();
+    }
+    .teams {
+        flex-grow: 1;
+        display: flex;
+        flex-direction: column;
     }
 </style>

--- a/frontend/src/pages/Home.svelte
+++ b/frontend/src/pages/Home.svelte
@@ -235,7 +235,7 @@
     }
     .availableBots {
         padding-bottom: 0.6rem;
-        flex-grow: 2;
+        height: 66.67%;
         display: flex;
         flex-direction: column;
     }
@@ -252,7 +252,7 @@
         filter: invert();
     }
     .teams {
-        flex-grow: 1;
+        height: 33.33%;
         display: flex;
         flex-direction: column;
     }

--- a/frontend/src/pages/Home.svelte
+++ b/frontend/src/pages/Home.svelte
@@ -28,6 +28,7 @@
     );
 
     let players: DraggablePlayer[] = $state([...BASE_PLAYERS]);
+    let selectedTeam = $state(null);
 
     let loadingPlayers = $state(false);
     let latestBotUpdateTime = null;
@@ -181,10 +182,17 @@
             <div style="flex:1"></div>
             <input type="text" class="botSearch" placeholder="Search..." oninput={handleSearch}/>
         </header>
-        <BotList bind:showHuman items={players} searchQuery={searchQuery} />
+        <BotList
+            bind:bluePlayers
+            bind:orangePlayers
+            bind:showHuman
+            items={players}
+            searchQuery={searchQuery}
+            selectedTeam={selectedTeam}
+        />
     </div>
 
-    <div class="teams"><Teams bind:bluePlayers bind:orangePlayers /></div>
+    <div class="teams"><Teams bind:bluePlayers bind:orangePlayers bind:selectedTeam /></div>
 
     <div class="box">
         <MatchSettings

--- a/frontend/src/pages/Home.svelte
+++ b/frontend/src/pages/Home.svelte
@@ -23,7 +23,7 @@
     const backgroundImage =
         arenaImages[Math.floor(Math.random() * arenaImages.length)];
 
-    let paths = $state(
+    let paths: { tagName: string | null, repo: string | null, installPath: string }[] = $state(
         JSON.parse(window.localStorage.getItem("BOT_SEARCH_PATHS") || "[]"),
     );
 
@@ -38,7 +38,7 @@
         loadingPlayers = true;
         let internalUpdateTime = new Date();
         latestBotUpdateTime = internalUpdateTime;
-        const result = await App.GetBots(paths);
+        const result = await App.GetBots(paths.map((x) => x.installPath));
         if (latestBotUpdateTime !== internalUpdateTime) {
             return; // if newer "search" already started, dont write old data
         }

--- a/frontend/src/pages/RocketHost.svelte
+++ b/frontend/src/pages/RocketHost.svelte
@@ -15,7 +15,7 @@
             [name: string]: string[];
         } = {};
         for (let bot of bots) {
-            let fam = bot.family != "" ? bot.family : bot.name;
+            let fam = bot.family !== "" ? bot.family : bot.name;
             if (!families.hasOwnProperty(fam)) {
                 families[fam] = [];
             }

--- a/frontend/src/settings.ts
+++ b/frontend/src/settings.ts
@@ -1,7 +1,7 @@
 import { writable } from 'svelte/store';
 import { MAPS_STANDARD } from './arena-names';
 
-export const mapStore = writable(localStorage.getItem("MS_MAP") || MAPS_STANDARD.DFHStadium);
+export const mapStore = writable(localStorage.getItem("MS_MAP") || MAPS_STANDARD["DFH Stadium"]);
 mapStore.subscribe(value => {
     localStorage.setItem("MS_MAP", value);
 });

--- a/github.go
+++ b/github.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/ulikunitz/xz"
+)
+
+type GhRelease struct {
+	URL             string    `json:"url"`
+	AssetsURL       string    `json:"assets_url"`
+	UploadURL       string    `json:"upload_url"`
+	HTMLURL         string    `json:"html_url"`
+	ID              int       `json:"id"`
+	Author          GhAuthor  `json:"author"`
+	NodeID          string    `json:"node_id"`
+	TagName         string    `json:"tag_name"`
+	TargetCommitish string    `json:"target_commitish"`
+	Name            string    `json:"name"`
+	Draft           bool      `json:"draft"`
+	Prerelease      bool      `json:"prerelease"`
+	CreatedAt       time.Time `json:"created_at"`
+	PublishedAt     time.Time `json:"published_at"`
+	Assets          []GhAsset `json:"assets"`
+	TarballURL      string    `json:"tarball_url"`
+	ZipballURL      string    `json:"zipball_url"`
+	Body            string    `json:"body"`
+}
+
+type GhAuthor struct {
+	Login             string `json:"login"`
+	ID                int    `json:"id"`
+	NodeID            string `json:"node_id"`
+	AvatarURL         string `json:"avatar_url"`
+	GravatarID        string `json:"gravatar_id"`
+	URL               string `json:"url"`
+	HTMLURL           string `json:"html_url"`
+	FollowersURL      string `json:"followers_url"`
+	FollowingURL      string `json:"following_url"`
+	GistsURL          string `json:"gists_url"`
+	StarredURL        string `json:"starred_url"`
+	SubscriptionsURL  string `json:"subscriptions_url"`
+	OrganizationsURL  string `json:"organizations_url"`
+	ReposURL          string `json:"repos_url"`
+	EventsURL         string `json:"events_url"`
+	ReceivedEventsURL string `json:"received_events_url"`
+	Type              string `json:"type"`
+	SiteAdmin         bool   `json:"site_admin"`
+}
+
+type GhAsset struct {
+	URL                string    `json:"url"`
+	ID                 int       `json:"id"`
+	NodeID             string    `json:"node_id"`
+	Name               string    `json:"name"`
+	Label              string    `json:"label"`
+	Uploader           GhAuthor  `json:"uploader"`
+	ContentType        string    `json:"content_type"`
+	State              string    `json:"state"`
+	Size               int       `json:"size"`
+	DownloadCount      int       `json:"download_count"`
+	CreatedAt          time.Time `json:"created_at"`
+	UpdatedAt          time.Time `json:"updated_at"`
+	BrowserDownloadURL string    `json:"browser_download_url"`
+}
+
+func ParseReleaseData(data []byte) (GhRelease, error) {
+	var release GhRelease
+	err := json.Unmarshal(data, &release)
+	if err != nil {
+		return GhRelease{}, err
+	}
+
+	return release, nil
+}
+
+// taken from https://medium.com/@skdomino/taring-untaring-files-in-go-6b07cf56bc07
+func extractTar(tr *tar.Reader, dst string) error {
+	for {
+		header, err := tr.Next()
+
+		switch {
+
+		// if no more files are found return
+		case err == io.EOF:
+			return nil
+
+		// return any other error
+		case err != nil:
+			return err
+
+		// if the header is nil, just skip it (not sure how this happens)
+		case header == nil:
+			continue
+		}
+
+		// the target location where the dir/file should be created
+		target := filepath.Join(dst, header.Name)
+
+		// the following switch could also be done using fi.Mode(), not sure if there
+		// a benefit of using one vs. the other.
+		// fi := header.FileInfo()
+
+		// check the file type
+		switch header.Typeflag {
+
+		// if its a dir and it doesn't exist create it
+		case tar.TypeDir:
+			if _, err := os.Stat(target); err != nil {
+				if err := os.MkdirAll(target, 0755); err != nil {
+					return err
+				}
+			}
+
+		// if it's a file create it
+		case tar.TypeReg:
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
+			if err != nil {
+				return err
+			}
+
+			// copy over contents
+			if _, err := io.Copy(f, tr); err != nil {
+				return err
+			}
+
+			// manually close here after each file operation; defering would cause each file close
+			// to wait until all operations have completed.
+			f.Close()
+		}
+	}
+}
+
+func DownloadExtractArchive(url string, dest string) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	// body is a .tar.xz file
+	xzr, err := xz.NewReader(bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+
+	tr := tar.NewReader(xzr)
+	err = extractTar(tr, dest)
+	return err
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/BurntSushi/toml v1.4.0
 	github.com/ncruces/zenity v0.10.14
 	github.com/swz-git/go-interface v0.0.0-20250223222446-f9cf3451531b
+	github.com/ulikunitz/xz v0.5.12
 	github.com/wailsapp/mimetype v1.4.1
 	github.com/wailsapp/wails/v3 v3.0.0-alpha.9
 )

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/swz-git/go-interface v0.0.0-20250223222446-f9cf3451531b h1:MeJIpQfaQR5ct+9k1E5TEhI0gBMgvBx9nNLZZhJF+MA=
 github.com/swz-git/go-interface v0.0.0-20250223222446-f9cf3451531b/go.mod h1:Fnu6IUjNzFw0QsRnxu5vTfdq3bCkxjg51oDYEaLIxJs=
+github.com/ulikunitz/xz v0.5.12 h1:37Nm15o69RwBkXM0J6A5OlE67RZTfzUxTj8fB3dfcsc=
+github.com/ulikunitz/xz v0.5.12/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/wailsapp/go-webview2 v1.0.19 h1:7U3QcDj1PrBPaxJNCui2k1SkWml+Q5kvFUFyTImA6NU=
 github.com/wailsapp/go-webview2 v1.0.19/go.mod h1:qJmWAmAmaniuKGZPWwne+uor3AHMB5PFhqiK0Bbj8kc=
 github.com/wailsapp/mimetype v1.4.1 h1:pQN9ycO7uo4vsUUuPeHEYoUkLVkaRntMnHJxVwYhwHs=

--- a/main.go
+++ b/main.go
@@ -27,8 +27,8 @@ func main() {
 	// Create application with options
 	app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
 		Title:     "RLBotGUI",
-		Width:     1024,
-		Height:    768,
+		Width:     1300,
+		Height:    870,
 		MinWidth:  600,
 		MinHeight: 400,
 		// AssetServer: &assetserver.Options{

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ func main() {
 	app := application.New(application.Options{
 		Name: "rlbotgui",
 		Services: []application.Service{
-			application.NewService(&App{}),
+			application.NewService(NewApp()),
 		},
 		Assets: application.AssetOptions{
 			Handler: application.AssetFileServerFS(assets),
@@ -35,7 +35,6 @@ func main() {
 		// 	Assets: assets,
 		// },
 		BackgroundColour: application.NewRGBA(27, 38, 54, 1),
-		// OnStartup:        app.startup,
 		// Bind: []interface{}{
 		// 	app,
 		// 	&HumanInfo{},

--- a/rockethost.go
+++ b/rockethost.go
@@ -141,10 +141,9 @@ func (a *App) StartRHostMatch(settings RHostMatchSettings) (string, error) {
 	}()
 
 	// TODO: Save this in App struct
-	// TODO: Make dynamic, pull from env var?
-	conn, err := rlbot.Connect("127.0.0.1:23234")
+	conn, err := rlbot.Connect(a.rlbot_address)
 	if err != nil {
-		return "", errors.New("Couldn't connect to RLBotServer")
+		return "", errors.New("Failed to connect to RLBotServer at " + a.rlbot_address)
 	}
 
 	var launcher flat.Launcher


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fbf58c8a-76c0-4a78-b372-ac01829c379c)

- User setting for "Randomize map" is now remembered
- Window size is now the same as v4
- Bot list / team bot lists now take up the full height
- Better tags! e.x. both "Standard" and "Bots for 1v1" can be selected
- Search works!
- Address for connecting to RLBotServer is now read from `RLBOT_SERVER_IP` and `RLBOT_SERVER_PORT` which is saved in the app struct
- The bot list is now sorted by names
- Refine "Add/remove" - instead of a dropdown, it's now a modal:
  
  ![image](https://github.com/user-attachments/assets/ec610511-8ffb-4b36-8616-b0586bc40cbf)

- Only 1 human is allowed to be picked, it's hidden after that. When not hidden, it shows up in every category:

  ![image](https://github.com/user-attachments/assets/c4305703-1182-40dd-b2c9-d345f8516a3e)

  ![image](https://github.com/user-attachments/assets/77acddc1-7207-4c93-b886-daa3c614f0f5)

- Added click-to-add for bots. Click orange, it gets highlight, click a bot, it gets added to orange. Click orange again, and no team is selected and it's not highlighted anymore (same for blue btw - the outline around the team bot list is subtle):

  ![image](https://github.com/user-attachments/assets/e73120bd-16ed-4b18-bac5-62fd2c5a5aca)

- Initial botpack support! No incremental patches but it can download. When you click "Add botpack" in "Add/remove":

  ![image](https://github.com/user-attachments/assets/f6ecaaba-3c1b-4f54-92df-85407190f6e9)

  The official botpack is the default, but you can add additional custom botpacks that are hosted on github:

  ![image](https://github.com/user-attachments/assets/f519ca69-cb7f-4c53-bea6-581f69799499)
