### PR TITLE
Fix match start

### DIFF
--- a/frontend/src/components/MatchSettings/Main.svelte
+++ b/frontend/src/components/MatchSettings/Main.svelte
@@ -23,9 +23,9 @@ $effect(() => {
 });
 
 const existingMatchBehaviors: { [n: string]: number } = {
-  "Restart if different": 0,
-  Restart: 1,
-  "Continue and spawn": 2,
+  Restart: 0,
+  "Continue and spawn": 1,
+  "Restart if different": 2,
 };
 
 function cleanCase(toClean: string) {

--- a/github.go
+++ b/github.go
@@ -160,3 +160,34 @@ func DownloadExtractArchive(url string, dest string) error {
 	err = extractTar(tr, dest)
 	return err
 }
+
+func (a *App) GetLatestReleaseData(repo string) (*GhRelease, error) {
+	latest_release_url := "https://api.github.com/repos/" + repo + "/releases/latest"
+
+	resp, err := http.Get(latest_release_url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	content, err := ParseReleaseData(body)
+	if err != nil {
+		return nil, err
+	}
+
+	a.latest_release_json = append(a.latest_release_json, RawReleaseInfo{repo, content})
+
+	return &a.latest_release_json[len(a.latest_release_json)-1].content, nil
+}
+
+// func (a *App) CheckForNewRelease(tag string) (bool, error) {
+// 	//go:build !production
+// 	return false, nil
+
+// 	return false, nil
+// }

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"embed"
 	"log"
+	"log/slog"
 
 	"github.com/wailsapp/wails/v3/pkg/application"
 	// "github.com/wailsapp/wails/v3/pkg/options"
@@ -19,6 +20,7 @@ func main() {
 		Services: []application.Service{
 			application.NewService(NewApp()),
 		},
+		LogLevel: slog.LevelWarn,
 		Assets: application.AssetOptions{
 			Handler: application.AssetFileServerFS(assets),
 		},

--- a/rockethost.go
+++ b/rockethost.go
@@ -54,8 +54,7 @@ func (a *App) GetRHostBots() ([]RHostBot, error) {
 			if !ok {
 				return nil, errors.New("invalid json shape: family object doesn't have \"name\"")
 			}
-			fart, _ := json.Marshal(botFamily["versions"])
-			print(string(fart))
+
 			familyBots, ok := botFamily["versions"].([]interface{})
 			if !ok {
 				return nil, errors.New("invalid json shape: family object doesn't have \"versions\"")


### PR DESCRIPTION
- Ensures player configurations are properly written
- Properly close the connection to the gui after the match start packet was sent
- Set default log level to warn to wails doesn't print every call into Go (fixes #3 )
- Let the GUI pick Psyonix bot loadouts
- Load custom bot loadouts
- Correctly write existing match behavior options