### PR TITLE
Download all intermediate patches for botpacks

### DIFF
--- a/frontend/src/pages/Home.svelte
+++ b/frontend/src/pages/Home.svelte
@@ -230,7 +230,8 @@ $effect(() => {
 });
 let extraOptions = $state(
   JSON.parse(
-    localStorage.getItem("MS_EXTRAOPTIONS") || '{"enableStateSetting": true}',
+    localStorage.getItem("MS_EXTRAOPTIONS") ||
+      '{"enableStateSetting": true,"existingMatchBehavior": 0}',
   ),
 );
 $effect(() => {

--- a/rockethost.go
+++ b/rockethost.go
@@ -161,8 +161,8 @@ func (a *App) StartRHostMatch(settings RHostMatchSettings) (string, error) {
 	}
 
 	err = conn.SendPacket(&flat.MatchConfigurationT{
-		PlayerConfigurations: []*flat.PlayerConfigurationT{},
-		ScriptConfigurations: []*flat.ScriptConfigurationT{},
+		PlayerConfigurations:  []*flat.PlayerConfigurationT{},
+		ScriptConfigurations:  []*flat.ScriptConfigurationT{},
 		GameMode:              flat.GameModeSoccer,
 		Mutators:              &flat.MutatorSettingsT{},
 		ExistingMatchBehavior: flat.ExistingMatchBehaviorRestart,

--- a/rockethost.go
+++ b/rockethost.go
@@ -162,15 +162,7 @@ func (a *App) StartRHostMatch(settings RHostMatchSettings) (string, error) {
 
 	err = conn.SendPacket(&flat.MatchConfigurationT{
 		PlayerConfigurations: []*flat.PlayerConfigurationT{},
-		ScriptConfigurations: []*flat.ScriptConfigurationT{
-			{
-				Name:       "GUIv5",
-				RootDir:    "",
-				RunCommand: "",
-				SpawnId:    0,
-				AgentId:    "rlbot/gui",
-			},
-		},
+		ScriptConfigurations: []*flat.ScriptConfigurationT{},
 		GameMode:              flat.GameModeSoccer,
 		Mutators:              &flat.MutatorSettingsT{},
 		ExistingMatchBehavior: flat.ExistingMatchBehaviorRestart,
@@ -185,7 +177,7 @@ func (a *App) StartRHostMatch(settings RHostMatchSettings) (string, error) {
 	}
 
 	err = conn.SendPacket(&flat.ConnectionSettingsT{
-		AgentId:              "rlbot/gui",
+		AgentId:              "",
 		WantsBallPredictions: false,
 		WantsComms:           false,
 		CloseBetweenMatches:  false,


### PR DESCRIPTION
I've verified that the download URLs are valid & correct

Assumed format of a tag is `*-[0-9]+` so as long as there's a `-` and then a number this will work

- 2 cherry picked patches (one for rockethost, one for the initial existing match behavior)

The purpose of this PR is to be minimal bug fixes with no new features so a new beta can potentially be pushed out sooner.