### PR TITLE
Reload team bot lists

### DIFF
--- a/frontend/src/pages/Home.svelte
+++ b/frontend/src/pages/Home.svelte
@@ -157,6 +157,39 @@ function distinguishDuplicates(pool: BotInfo[]): [BotInfo, string?][] {
   return uniquePathSegments;
 }
 
+function updateTeam(team: DraggablePlayer[]) {
+  let newTeam: DraggablePlayer[] = [];
+  for (let player of team) {
+    const botInfo = player.player;
+    if (!(botInfo instanceof BotInfo)) {
+      newTeam.push(player);
+      continue;
+    }
+
+    const found = players.find(
+      (p) => p.player instanceof BotInfo && p.player.tomlPath === botInfo.tomlPath,
+    );
+    if (!found) {
+      // bot was removed
+      continue;
+    }
+
+    let newPlayer: DraggablePlayer = {
+      ...found,
+      id: player.id,
+      modified: player.modified,
+    };
+    if (player.modified) {
+      // keep the modified display name
+      newPlayer.displayName = player.displayName;
+    }
+
+    newTeam.push(newPlayer);
+  }
+
+  return newTeam;
+}
+
 async function updateBots() {
   loadingPlayers = true;
   const internalUpdateTime = new Date();
@@ -171,6 +204,7 @@ async function updateBots() {
   if (latestBotUpdateTime !== internalUpdateTime) {
     return; // if newer "search" already started, dont write old data
   }
+
   players = players.concat(
     distinguishDuplicates(result).map(([x, uniquePathSegment]) => {
       return {
@@ -184,6 +218,9 @@ async function updateBots() {
       };
     }),
   );
+
+  bluePlayers = updateTeam(bluePlayers);
+  orangePlayers = updateTeam(orangePlayers);
 
   loadingPlayers = false;
 }


### PR DESCRIPTION
- If a player is not a custom bot, it always gets added to the list
- If a custom bot is not found, it gets removed from the list
- If a custom bot was given a custom name, that name is preserved - otherwise, the display name is updated
- Order of players in the list is preserved
- UUID of the players are preserved

I tested this and it appears to work pretty well. Fixes #49 