### PR TITLE
Fix building on newest Wails v3 alpha

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -82,17 +82,15 @@ tasks:
   ## -------------------------- Misc -------------------------- ##
 
   generate:icons:
-    summary: Generates Windows `.ico` and Mac `.icns` files from an image
+    summary: Generates Windows `.ico` file from an image
     dir: build
     sources:
       - "appicon.png"
     generates:
-      - "icons.icns"
-      - "icons.ico"
+      - "icon.ico"
     cmds:
-      # Generates both .ico and .icns files
-      - wails3 generate icons -input appicon.png
-      - rm icons.icns # remove mac icons
+      # Generates both .ico
+      - wails3 generate icons -input appicon.png -windowsfilename icon.ico
 
   install:frontend:deps:
     summary: Install frontend dependencies


### PR DESCRIPTION
After installing Wails v3 alpha 71, I was getting:

```
  ERROR   either windows filename or mac filename is required
```

This PR fixes that issue. Only specifying the Windows file name also prevents generation of the Mac `.icns` files.