### PR TITLE
Show mutator count

### DIFF
--- a/frontend/src/components/MatchSettings/Main.svelte
+++ b/frontend/src/components/MatchSettings/Main.svelte
@@ -281,8 +281,8 @@ const ALL_MAPS = getMaps();
   }
   .controls button span {
     margin-left: 0.5rem;
-    background-color: red;
-    color: white;
+    background-color: var(--orange);
+    color: var(--foreground-opp);
     padding: 0.1rem 0.3rem;
     border-radius: 0.2rem;
   }


### PR DESCRIPTION
Default vs with the Car Wars preset:

<img width="517" height="164" alt="image" src="https://github.com/user-attachments/assets/ccda01ed-bbc7-4978-a58f-253bef374789" />

<img width="517" height="164" alt="image" src="https://github.com/user-attachments/assets/ddbc85aa-ee1c-4b59-91c4-8e996936c944" />

This mirrors missing functionality from the v4 gui. It's really nice to be able to know if you have any mutators selected at a glance.