### PR TITLE
Persistent team bot config

### DIFF
--- a/frontend/src/pages/Home.svelte
+++ b/frontend/src/pages/Home.svelte
@@ -110,14 +110,25 @@ let latestBotUpdateTime = null;
 let loadingPlayers = $state(false);
 
 let players: DraggablePlayer[] = $state(BASE_PLAYERS.slice(1));
-let bluePlayers: DraggablePlayer[] = $state([BASE_PLAYERS[0]]);
-let orangePlayers: DraggablePlayer[] = $state([]);
+let bluePlayers: DraggablePlayer[] = $state(
+  parseJSON(localStorage.getItem("BLUE_PLAYERS")) || [BASE_PLAYERS[0]],
+);
+let orangePlayers: DraggablePlayer[] = $state(
+  parseJSON(localStorage.getItem("ORANGE_PLAYERS")) || [],
+);
 let showHuman = $derived(
   !(
     bluePlayers.some((x) => x.tags.includes("human")) ||
     orangePlayers.some((x) => x.tags.includes("human"))
   ),
 );
+
+$effect(() => {
+  localStorage.setItem("BLUE_PLAYERS", JSON.stringify(bluePlayers));
+});
+$effect(() => {
+  localStorage.setItem("ORANGE_PLAYERS", JSON.stringify(orangePlayers));
+});
 
 let latestScriptUpdateTime = null;
 let loadingScripts = $state(false);


### PR DESCRIPTION
Closes #74 

I did test and this _does_ work. The blue team successfully defaults to having a human when `"BLUE_PLAYERS"` is missing from local storage, and doesn't do so when it's merely empty.