### PR TITLE
Fix subfolder not being appended to path on Windows

### DIFF
--- a/app.go
+++ b/app.go
@@ -39,7 +39,7 @@ func (a *App) IgnoreMe(
 func (a *App) GetDefaultPath(subfolder string) string {
 	if runtime.GOOS == "windows" {
 		localappdata := os.Getenv("LOCALAPPDATA")
-		return filepath.Join(localappdata, "RLBot5")
+		return filepath.Join(localappdata, "RLBot5", subfolder)
 	}
 
 	// assume linux

--- a/frontend/src/components/AddBotpack.svelte
+++ b/frontend/src/components/AddBotpack.svelte
@@ -4,10 +4,7 @@ import { App } from "../../bindings/gui";
 import Modal from "./Modal.svelte";
 import ProgressBar from "./ProgressBar.svelte";
 
-const OFFICIAL_BOTPACK_REPOS = [
-  "RLBot/botpack",
-  "VirxEC/pytorch-archive",
-];
+const OFFICIAL_BOTPACK_REPOS = ["RLBot/botpack", "VirxEC/pytorch-archive"];
 
 let {
   visible = $bindable(false),

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -24,26 +24,26 @@ const app: any = mount(App, {
 
 export function parseJSON(item: string | null): any | null {
   if (item === null) {
-    return null
+    return null;
   }
 
   try {
     return JSON.parse(item);
   } catch (e) {
-    console.warn("JSON Parse error", e)
+    console.warn("JSON Parse error", e);
     return null;
   }
 }
 
 export function parseSuperJSON(item: string | null): any | null {
   if (item === null) {
-    return null
+    return null;
   }
 
   try {
     return SuperJSON.parse(item);
   } catch (e) {
-    console.warn("SuperJSON Parse error", e)
+    console.warn("SuperJSON Parse error", e);
     return null;
   }
 }

--- a/players.go
+++ b/players.go
@@ -163,7 +163,7 @@ type BotInfo struct {
 	Config   BotConfig      `json:"config"`
 	Loadout  *LoadoutConfig `json:"loadout,omitempty"`
 	TomlPath string         `json:"tomlPath"`
-	Icon 	 string 		`json:"icon"`
+	Icon     string         `json:"icon"`
 }
 
 func (botInfo BotInfo) ToPlayerConfig(team uint32) *flat.PlayerConfigurationT {
@@ -280,7 +280,7 @@ func (a *App) GetBots(paths []string) []BotInfo {
 		}
 
 		// Read logo file and convert it to data url so the frontend can use it
-		var icon string;
+		var icon string
 		logo_data, err := os.ReadFile(logo_file)
 		if err != nil {
 			// only warn if the logo file was explicitly set
@@ -306,7 +306,7 @@ func (a *App) GetBots(paths []string) []BotInfo {
 			Config:   conf,
 			Loadout:  loadout,
 			TomlPath: potentialConfigPath,
-			Icon: icon,
+			Icon:     icon,
 		})
 	}
 


### PR DESCRIPTION
Fixes #95 and brings back the intended behavior on Windows.