### PR TITLE
Add RocketHost lobby browser

### DIFF
--- a/frontend/src/components/RLLobby.svelte
+++ b/frontend/src/components/RLLobby.svelte
@@ -1,0 +1,154 @@
+<script lang="ts">
+import toast from "svelte-5-french-toast";
+import { App, RLLobbyListing } from "../../bindings/gui/index.js";
+import Modal from "./Modal.svelte";
+
+let {
+  servers = $bindable(),
+  launcherOptionsVisible = $bindable(),
+  visible = $bindable(false),
+} = $props();
+let joiningLobbyId = $state<string | null>(null);
+
+function getServerName(name: string, ipAddress: string) {
+  if (servers) {
+    const server = servers.find((s) => s.ip === ipAddress);
+    if (server) {
+      return server.location;
+    }
+  }
+
+  return name.replace(/:\d+$/, "");
+}
+
+async function joinLobby(lobby: RLLobbyListing) {
+  if (joiningLobbyId) return;
+
+  let launcher = localStorage.getItem("MS_LAUNCHER");
+  if (!launcher) {
+    toast.error("Please select a launcher first", {
+      position: "top-center",
+      duration: 5000,
+    });
+
+    launcherOptionsVisible = true;
+    return;
+  }
+
+  joiningLobbyId = lobby.id;
+  const serverAddr = `${lobby.ipAddress}:${lobby.port}`;
+  const lobbyName = getServerName(lobby.name, lobby.ipAddress);
+  const toastId = toast.loading(`Joining ${lobbyName}...`, {
+    position: "top-center",
+  });
+
+  try {
+    await App.JoinLobby({
+      server: serverAddr,
+      map: lobby.map,
+      blueBots: [],
+      orangeBots: [],
+      launcher,
+      launcherArg: localStorage.getItem("MS_LAUNCHER_ARG") || "",
+    });
+    toast.success(`Joining ${lobbyName}`, {
+      id: toastId,
+      position: "top-center",
+      duration: 5000,
+    });
+  } catch (error) {
+    toast.error(`Failed to join lobby\n${error}`, {
+      id: toastId,
+      position: "top-center",
+      duration: 8000,
+    });
+  } finally {
+    joiningLobbyId = null;
+  }
+}
+</script>
+
+<Modal title="RocketHost Lobbies" bind:visible>
+  {#if visible}
+    {#await App.GetRLLobbies()}
+      <p>Loading lobbies...</p>
+    {:then lobbies}
+      {#if lobbies.length === 0}
+        <p>No public lobbies found.</p>
+      {:else}
+        <div class="lobbyList">
+          {#each lobbies as lobby}
+            <div class="lobbyEntry">
+              <div class="lobbyHeader">
+                <h3>{getServerName(lobby.name, lobby.ipAddress)}</h3>
+                <div class="lobbyActions">
+                  <span>{lobby.playerCount} player(s)</span>
+                  <button
+                    class="join"
+                    disabled={joiningLobbyId === lobby.id}
+                    onclick={() => joinLobby(lobby)}
+                  >
+                    {joiningLobbyId === lobby.id ? "Joining..." : "Join"}
+                  </button>
+                </div>
+              </div>
+              <div class="lobbyMeta">
+                <span>{lobby.map}</span>
+                <span>|</span>
+                <span>{lobby.secondsSinceUpdate}s ago</span>
+              </div>
+            </div>
+          {/each}
+        </div>
+      {/if}
+    {:catch error}
+      <p class="lobbyError">Failed to load lobbies: {error?.message || error}</p>
+    {/await}
+  {/if}
+</Modal>
+
+<style>
+  .lobbyList {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    min-width: 350px;
+  }
+  .lobbyEntry {
+    background-color: var(--background-alt);
+    border-radius: 0.4rem;
+    padding: 0.6rem 0.8rem;
+  }
+  .lobbyHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+  }
+  .lobbyActions {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+  }
+  button.join {
+    background-color: #15680e;
+  }
+  button.join:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+  }
+  .lobbyHeader h3 {
+    margin: 0;
+    font-size: 1.1rem;
+  }
+  .lobbyMeta {
+    display: flex;
+    gap: 0.6rem;
+    font-size: 0.9rem;
+    opacity: 0.85;
+  }
+  .lobbyError {
+    color: var(--orange);
+    font-weight: 600;
+  }
+</style>

--- a/frontend/src/components/RLLobby.svelte
+++ b/frontend/src/components/RLLobby.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import toast from "svelte-5-french-toast";
 import { App, RLLobbyListing } from "../../bindings/gui/index.js";
+import reloadIcon from "../assets/reload.svg";
 import Modal from "./Modal.svelte";
 
 let {
@@ -9,6 +10,37 @@ let {
   visible = $bindable(false),
 } = $props();
 let joiningLobbyId = $state<string | null>(null);
+let lobbies = $state<RLLobbyListing[]>([]);
+let lobbiesLoading = $state(false);
+let lobbiesError = $state<string | null>(null);
+let hasLoaded = $state(false);
+
+async function loadLobbies() {
+  if (lobbiesLoading) return;
+  lobbiesLoading = true;
+  lobbiesError = null;
+
+  try {
+    lobbies = await App.GetRLLobbies();
+    hasLoaded = true;
+  } catch (error) {
+    lobbiesError = error?.message || String(error);
+  } finally {
+    lobbiesLoading = false;
+  }
+}
+
+$effect(() => {
+  if (!visible && hasLoaded) {
+    hasLoaded = false;
+  }
+});
+
+$effect(() => {
+  if (visible && !hasLoaded) {
+    loadLobbies();
+  }
+});
 
 function getServerName(name: string, ipAddress: string) {
   if (servers) {
@@ -68,51 +100,80 @@ async function joinLobby(lobby: RLLobbyListing) {
 }
 </script>
 
-<Modal title="RocketHost Lobbies" bind:visible>
-  {#if visible}
-    {#await App.GetRLLobbies()}
-      <p>Loading lobbies...</p>
-    {:then lobbies}
-      {#if lobbies.length === 0}
-        <p>No public lobbies found.</p>
-      {:else}
-        <div class="lobbyList">
-          {#each lobbies as lobby}
-            <div class="lobbyEntry">
-              <div class="lobbyHeader">
-                <h3>{getServerName(lobby.name, lobby.ipAddress)}</h3>
-                <div class="lobbyActions">
-                  <span>{lobby.playerCount} player(s)</span>
-                  <button
-                    class="join"
-                    disabled={joiningLobbyId === lobby.id}
-                    onclick={() => joinLobby(lobby)}
-                  >
-                    {joiningLobbyId === lobby.id ? "Joining..." : "Join"}
-                  </button>
-                </div>
-              </div>
-              <div class="lobbyMeta">
-                <span>{lobby.map}</span>
-                <span>|</span>
-                <span>{lobby.secondsSinceUpdate}s ago</span>
-              </div>
+{#snippet lobbyTitle()}
+  <div class="lobbyTitle">
+    <span>RocketHost Lobbies</span>
+    <button
+      class="refresh"
+      type="button"
+      title="Refresh lobbies"
+      disabled={lobbiesLoading}
+      onclick={loadLobbies}
+    >
+      <img src={reloadIcon} alt="Refresh lobbies" />
+    </button>
+  </div>
+{/snippet}
+
+<Modal title={lobbyTitle} bind:visible>
+  {#if !hasLoaded && lobbiesLoading}
+    <p>Loading lobbies...</p>
+  {:else if lobbies.length === 0 && !lobbiesError}
+    <p>No public lobbies found.</p>
+  {:else if lobbies.length > 0}
+    <div class="lobbyList">
+      {#each lobbies as lobby}
+        <div class="lobbyEntry">
+          <div class="lobbyHeader">
+            <h3>{getServerName(lobby.name, lobby.ipAddress)}:{lobby.port}</h3>
+            <div class="lobbyActions">
+              <span>{lobby.playerCount} player(s)</span>
+              <button
+                class="join"
+                disabled={joiningLobbyId === lobby.id}
+                onclick={() => joinLobby(lobby)}
+              >
+                {joiningLobbyId === lobby.id ? "Joining..." : "Join"}
+              </button>
             </div>
-          {/each}
+          </div>
+          <div class="lobbyMeta">
+            <span>{lobby.map}</span>
+            <span>|</span>
+            <span>{lobby.secondsSinceUpdate}s ago</span>
+          </div>
         </div>
-      {/if}
-    {:catch error}
-      <p class="lobbyError">Failed to load lobbies: {error?.message || error}</p>
-    {/await}
+      {/each}
+    </div>
+  {/if}
+
+  {#if lobbiesError}
+    <p class="lobbyError">Failed to load lobbies: {lobbiesError}</p>
   {/if}
 </Modal>
 
 <style>
+  .lobbyTitle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+  }
+  .lobbyTitle .refresh {
+    padding: 2px 4px 2px 4px;
+  }
+  .lobbyTitle .refresh:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+  }
+  .refresh img {
+    filter: invert() brightness(var(--icon-brightness));
+    width: 24px;
+  }
   .lobbyList {
     display: flex;
     flex-direction: column;
     gap: 0.6rem;
-    min-width: 350px;
+    min-width: 400px;
   }
   .lobbyEntry {
     background-color: var(--background-alt);

--- a/frontend/src/pages/RocketHost.svelte
+++ b/frontend/src/pages/RocketHost.svelte
@@ -73,6 +73,48 @@ refreshRHostServers();
 let blueBots: string[] = $state([]);
 let orangeBots: string[] = $state([]);
 let launcherOptionsVisible = $state(false);
+
+function startRHostMatch() {
+  let launcher = localStorage.getItem("MS_LAUNCHER");
+  if (!launcher) {
+    toast.error("Please select a launcher first", {
+      position: "top-center",
+      duration: 5000,
+    });
+
+    launcherOptionsVisible = true;
+    return;
+  }
+
+  waiting = true;
+  let id = toast.loading("Starting rocket host game...", {
+    position: "top-center",
+  });
+  App.StartRHostMatch({
+    server: serverAddr,
+    map: $mapStore,
+    blueBots,
+    orangeBots,
+    launcher,
+    launcherArg: localStorage.getItem("MS_LAUNCHER_ARG") || "",
+  })
+    .then((addr) => {
+      waiting = false;
+      toast.success(`Started game with address ${addr}`, {
+        position: "top-center",
+        duration: 10000,
+        id,
+      });
+    })
+    .catch((e) => {
+      waiting = false;
+      toast.error("Failed to start Rocket Host game\n" + e, {
+        position: "top-center",
+        duration: 8000,
+        id,
+      });
+    });
+}
 </script>
 
 <div class="page blurred">
@@ -161,64 +203,32 @@ let launcherOptionsVisible = $state(false);
   </div>
 
   <div class="options">
-    <div>
-      <label for="serverselect">Server</label>
-      <select name="serverselect" id="serverselect" bind:value={serverAddr}>
-        {#each servers as value, i}
-          <option value={`${value.ip}:${value.port}`}>{value.location}</option>
-        {/each}
-      </select>
-    </div>
-    <div>
-      <label for="mapselect">Map</label>
-      <select name="mapselect" id="mapselect" bind:value={$mapStore}>
-        {#each Object.entries(MAPS_STANDARD) as map, i}
-          <option value={map[1]}>{map[0]}</option>
-        {/each}
-      </select>
-    </div>
-    <div>
-      <button onclick={() => { launcherOptionsVisible = true }}>Launcher Options</button>
-    </div>
-    <button class="start" disabled={waiting} onclick={()=>{
-      let launcher = localStorage.getItem("MS_LAUNCHER");
-      if (!launcher) {
-        toast.error("Please select a launcher first", {
-          position: "top-center",
-          duration: 5000,
-        });
-
-        launcherOptionsVisible = true;
-        return;
-      }
-
-      waiting = true;
-      let id = toast.loading("Starting rocket host game...", {
-        position: "top-center"
-      })
-      App.StartRHostMatch({
-        server: serverAddr,
-        map: $mapStore,
-        blueBots,
-        orangeBots,
-        launcher,
-        launcherArg: localStorage.getItem("MS_LAUNCHER_ARG") || ''
-      }).then((addr)=>{
-        waiting = false;
-        toast.success(
-          `Started game with address ${addr}`,
-          {position: "top-center", duration: 10000, id}
-        )
-      }).catch((e)=>{
-        waiting = false;
-        toast.error(
-          "Failed to start Rocket Host game\n" + e,
-          {position: "top-center", duration: 8000, id}
-        )
-      })
-    }}>
-      Start
-    </button>
+    {#if servers.length > 0}
+      <div>
+        <label for="serverselect">Server</label>
+          <select name="serverselect" id="serverselect" bind:value={serverAddr}>
+            {#each servers as value, i}
+              <option value={`${value.ip}:${value.port}`}>{value.location}</option>
+            {/each}
+          </select>
+      </div>
+      <div>
+        <label for="mapselect">Map</label>
+        <select name="mapselect" id="mapselect" bind:value={$mapStore}>
+          {#each Object.entries(MAPS_STANDARD) as map, i}
+            <option value={map[1]}>{map[0]}</option>
+          {/each}
+        </select>
+      </div>
+      <div>
+        <button onclick={() => { launcherOptionsVisible = true }}>Launcher Options</button>
+      </div>
+      <button class="start" disabled={waiting} onclick={startRHostMatch}>
+        Start
+      </button>
+    {:else}
+      <div class="maintenance">RocketHost is currently down for maintenance. Please try again later.</div>
+    {/if}
   </div>
 
   <div class="donateBar" style="--icon-url: url({heartIcon});">
@@ -365,6 +375,17 @@ let launcherOptionsVisible = $state(false);
     filter: invert() brightness(var(--icon-brightness));;
     height: 28px;
     width: 28px;
+  }
+  .maintenance {
+    flex: 1;
+    text-align: center;
+    padding: 0.75rem 1rem;
+    border-radius: 0.5rem;
+    border: 1px solid var(--orange);
+    background-color: var(--background-alt);
+    color: var(--orange);
+    font-weight: 600;
+    line-height: 1.4;
   }
   .donateBar {
     display: flex;

--- a/frontend/src/pages/RocketHost.svelte
+++ b/frontend/src/pages/RocketHost.svelte
@@ -292,8 +292,18 @@ function startRHostMatch() {
   }
   .availableBotsList {
     display: inline-grid;
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(3, 1fr);
     gap: 0.4rem;
+  }
+  @media (max-width: 1250px) {
+    .availableBotsList {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+  @media (max-width: 850px) {
+    .availableBotsList {
+      grid-template-columns: repeat(1, 1fr);
+    }
   }
   .expandMe {
     flex-grow: 1;

--- a/frontend/src/pages/RocketHost.svelte
+++ b/frontend/src/pages/RocketHost.svelte
@@ -8,6 +8,7 @@ import Plus from "../assets/plus.svg.svelte";
 import LauncherSelector from "../components/LauncherSelector.svelte";
 import { mapStore } from "../settings";
 import Modal from "../components/Modal.svelte";
+import RLLobby from "../components/RLLobby.svelte";
 import { Browser } from "@wailsio/runtime";
 
 let waiting = $state(false);
@@ -73,6 +74,7 @@ refreshRHostServers();
 let blueBots: string[] = $state([]);
 let orangeBots: string[] = $state([]);
 let launcherOptionsVisible = $state(false);
+let lobbiesVisible = $state(false);
 
 function startRHostMatch() {
   let launcher = localStorage.getItem("MS_LAUNCHER");
@@ -221,6 +223,9 @@ function startRHostMatch() {
         </select>
       </div>
       <div>
+        <button onclick={() => { lobbiesVisible = true }}>Browse Lobbies</button>
+      </div>
+      <div>
         <button onclick={() => { launcherOptionsVisible = true }}>Launcher Options</button>
       </div>
       <button class="start" disabled={waiting} onclick={startRHostMatch}>
@@ -241,6 +246,8 @@ function startRHostMatch() {
     >Donate</button>
   </div>
 </div>
+
+<RLLobby bind:servers bind:launcherOptionsVisible bind:visible={lobbiesVisible} />
 
 <Modal title="Select a launcher" bind:visible={launcherOptionsVisible}>
   <LauncherSelector />

--- a/rockethost.go
+++ b/rockethost.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -82,11 +83,30 @@ type RHostServer struct {
 	Domain   string `json:"domain"`
 }
 
+type RLLobbyListing struct {
+	Id                 string   `json:"id"`
+	Name               string   `json:"name"`
+	Map                string   `json:"map"`
+	Description        string   `json:"description"`
+	PlayerCount        int      `json:"playerCount"`
+	Players            []string `json:"players"`
+	HasPassword        bool     `json:"hasPassword"`
+	IpAddress          string   `json:"ipAddress"`
+	Port               int      `json:"port"`
+	SecondsSinceUpdate int      `json:"secondsSinceUpdate"`
+}
+
+type RLLobbyResponse struct {
+	Lobbies []RLLobbyListing `json:"lobbies"`
+}
+
 func (a *App) GetRHostServers() ([]RHostServer, error) {
 	resp, err := http.Get("http://serverlist.jetfox.ovh/servers")
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
+
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		fmt.Printf("Error reading body: %v\n", err)
@@ -99,6 +119,37 @@ func (a *App) GetRHostServers() ([]RHostServer, error) {
 	}
 
 	return data, nil
+}
+
+func (a *App) GetRLLobbies() ([]RLLobbyListing, error) {
+	resp, err := http.Get("https://rllobby.martinn.no/rllobby/lobby")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Printf("Error reading body: %v\n", err)
+		return nil, err
+	}
+
+	var data RLLobbyResponse
+	if err := json.Unmarshal(body, &data); err != nil {
+		fmt.Printf("Error parsing JSON: %v\n", err)
+		return nil, err
+	}
+
+	// sort data by Name, then SecondsSinceUpdate (most recent first)
+	sort.Slice(data.Lobbies, func(i, j int) bool {
+		if data.Lobbies[i].Name == data.Lobbies[j].Name {
+			return data.Lobbies[i].SecondsSinceUpdate < data.Lobbies[j].SecondsSinceUpdate
+		}
+
+		return data.Lobbies[i].Name < data.Lobbies[j].Name
+	})
+
+	return data.Lobbies, nil
 }
 
 // /?mapName=ARC_Darc_P&gameMode=TAGame.GameInfo_Soccar_TA&
@@ -269,4 +320,81 @@ outer:
 	conn.SendPacket(&flat.DisconnectSignalT{})
 
 	return result.Message, nil
+}
+
+func (a *App) JoinLobby(settings RHostMatchSettings) error {
+	if settings.Server == "" {
+		return errors.New("server is required")
+	}
+
+	conn, err := rlbot.Connect(a.rlbotAddress)
+	if err != nil {
+		return errors.New("Failed to connect to RLBotServer at " + a.rlbotAddress)
+	}
+
+	var launcher flat.Launcher
+	switch settings.Launcher {
+	case "steam":
+		launcher = flat.LauncherSteam
+	case "epic":
+		launcher = flat.LauncherEpic
+	case "custom":
+		launcher = flat.LauncherCustom
+	case "nolaunch":
+		launcher = flat.LauncherNoLaunch
+	default:
+		println("No launcher chosen, defaulting to NoLaunch")
+		launcher = flat.LauncherNoLaunch
+	}
+
+	err = conn.SendPacket(&flat.MatchConfigurationT{
+		PlayerConfigurations:  []*flat.PlayerConfigurationT{},
+		ScriptConfigurations:  []*flat.ScriptConfigurationT{},
+		GameMode:              flat.GameModeSoccar,
+		Mutators:              &flat.MutatorSettingsT{},
+		ExistingMatchBehavior: flat.ExistingMatchBehaviorRestart,
+		GameMapUpk:            settings.Map,
+		EnableStateSetting:    true,
+		EnableRendering:       flat.DebugRenderingOnByDefault,
+		Launcher:              launcher,
+		LauncherArg:           settings.LauncherArg,
+	})
+	if err != nil {
+		return errors.New("Couldn't send matchconfiguration packet")
+	}
+
+	err = conn.SendPacket(&flat.ConnectionSettingsT{
+		AgentId:              "",
+		WantsBallPredictions: false,
+		WantsComms:           false,
+		CloseBetweenMatches:  false,
+	})
+	if err != nil {
+		return errors.New("Couldn't send connectionsettings packet")
+	}
+
+	for {
+		packet, err := conn.RecvPacket()
+		if err != nil {
+			return errors.New("Error reading packet from rlbotserver: " + err.Error())
+		}
+		_, ok := packet.Value.(*flat.FieldInfoT)
+		if ok {
+			break
+		}
+	}
+
+	err = conn.SendPacket(&flat.DesiredGameStateT{
+		ConsoleCommands: []*flat.ConsoleCommandT{
+			{
+				Command: fmt.Sprintf("open %s?Lan?Password=", settings.Server),
+			},
+		},
+	})
+	if err != nil {
+		return errors.New("Couldn't send join message")
+	}
+
+	conn.SendPacket(&flat.DisconnectSignalT{})
+	return nil
 }

--- a/rockethost.go
+++ b/rockethost.go
@@ -140,12 +140,7 @@ func (a *App) GetRLLobbies() ([]RLLobbyListing, error) {
 		return nil, err
 	}
 
-	// sort data by Name, then SecondsSinceUpdate (most recent first)
 	sort.Slice(data.Lobbies, func(i, j int) bool {
-		if data.Lobbies[i].Name == data.Lobbies[j].Name {
-			return data.Lobbies[i].SecondsSinceUpdate < data.Lobbies[j].SecondsSinceUpdate
-		}
-
 		return data.Lobbies[i].Name < data.Lobbies[j].Name
 	})
 


### PR DESCRIPTION
- As a temporary helper with the growing list of RocketHost bots, the number of columns of bots has been upped to 3 and resizes itself based on screen width:
  <img width="1352" height="959" alt="image" src="https://github.com/user-attachments/assets/0c3195ef-855d-46f7-a180-e074b74a3029" />
  <img width="957" height="959" alt="image" src="https://github.com/user-attachments/assets/d749bb47-e1d0-453e-a151-4d053d285381" />
  <img width="752" height="959" alt="image" src="https://github.com/user-attachments/assets/3307145c-f885-4946-aed6-5fd02a5e8c2b" />

- When no RocketHost servers are listed, the join row is replaced with a down for maintenance message:
  <img width="1352" height="959" alt="image" src="https://github.com/user-attachments/assets/37c4f537-7b0a-464d-bc6c-3824348ccdf3" />
  <img width="1352" height="959" alt="image" src="https://github.com/user-attachments/assets/0719312e-fb51-4a11-83c8-bc7cc3f80052" />

- Added RocketHost lobby browser that allows the user to join existing lobbies
  <img width="1352" height="959" alt="image" src="https://github.com/user-attachments/assets/ef75039a-d18b-4861-8aae-0cbc8ddb755b" />
  <img width="1352" height="959" alt="image" src="https://github.com/user-attachments/assets/6f009030-15f3-4eac-8f26-549221c328fc" />