### PR TITLE
fix: persist enabled scripts

### DIFF
--- a/frontend/src/pages/Home.svelte
+++ b/frontend/src/pages/Home.svelte
@@ -135,7 +135,17 @@ $effect(() => {
 let latestScriptUpdateTime = null;
 let loadingScripts = $state(false);
 let scripts: ToggleableScript[] = $state([]);
-let enabledScripts: { [key: string]: boolean } = $state({});
+const enabledScriptsStorageKey = "ENABLED_SCRIPTS";
+let enabledScripts: { [key: string]: boolean } = $state(
+  parseJSON(localStorage.getItem(enabledScriptsStorageKey)) || {},
+);
+
+$effect(() => {
+  localStorage.setItem(
+    enabledScriptsStorageKey,
+    JSON.stringify(enabledScripts),
+  );
+});
 
 function distinguishDuplicates(pool: BotInfo[]): [BotInfo, string?][] {
   const uniqueNames = [
@@ -304,14 +314,6 @@ async function updateScripts() {
     }
   }
 
-  for (const agentId in Object.keys(enabledScripts)) {
-    if (
-      !scripts.some((script) => script.info.config.settings.agentId === agentId)
-    ) {
-      delete enabledScripts[agentId];
-    }
-  }
-
   loadingScripts = false;
 }
 
@@ -374,7 +376,9 @@ async function onMatchStart(randomizeMap: boolean) {
   const options: StartMatchOptions = {
     map: $mapStore,
     gameMode: mode,
-    scripts: scripts.filter((x) => enabledScripts[x.id]).map((x) => x.info),
+    scripts: scripts
+      .filter((x) => enabledScripts[x.info.config.settings.agentId])
+      .map((x) => x.info),
     bluePlayers: bluePlayers.map(draggablePlayerToPlayerJs),
     orangePlayers: orangePlayers.map(draggablePlayerToPlayerJs),
     launcher,


### PR DESCRIPTION
## Summary

Persists script toggle state across GUI restarts by loading `enabledScripts` from `localStorage` and writing it back whenever the state changes.

The UI already toggles scripts by `script.info.config.settings.agentId`, so match start now uses the same key when building `StartMatchOptions.scripts`. I also removed the stale-key cleanup during script discovery: missing entries are harmless, and keeping them avoids wiping saved selections if script discovery temporarily returns an incomplete list.

Closes #105

## Verification

- `git diff --check`
- `pnpm install --frozen-lockfile`
- `pnpm run build` *(blocked: generated Wails `frontend/bindings` are absent in a fresh checkout, so Vite cannot resolve `../bindings/gui`)*
