### PR TITLE
Cleanup name override implementation

### DIFF
--- a/frontend/src/base-players.ts
+++ b/frontend/src/base-players.ts
@@ -9,7 +9,7 @@ export const BASE_PLAYERS: DraggablePlayer[] = [
     id: crypto.randomUUID(),
     info: new HumanInfo(),
     tags: ["human"],
-    overrides: { name: "Human", loadout: null, autoStart: true },
+    overrides: { name: null, loadout: null, autoStart: true },
   },
   {
     displayName: "Psyonix Beginner",
@@ -20,7 +20,7 @@ export const BASE_PLAYERS: DraggablePlayer[] = [
       skill: 0,
     }),
     tags: ["psyonix"],
-    overrides: { name: "", loadout: null, autoStart: true },
+    overrides: { name: null, loadout: null, autoStart: true },
   },
   {
     displayName: "Psyonix Rookie",
@@ -31,7 +31,7 @@ export const BASE_PLAYERS: DraggablePlayer[] = [
       skill: 1,
     }),
     tags: ["psyonix"],
-    overrides: { name: "", loadout: null, autoStart: true },
+    overrides: { name: null, loadout: null, autoStart: true },
   },
   {
     displayName: "Psyonix Pro",
@@ -42,7 +42,7 @@ export const BASE_PLAYERS: DraggablePlayer[] = [
       skill: 2,
     }),
     tags: ["psyonix"],
-    overrides: { name: "", loadout: null, autoStart: true },
+    overrides: { name: null, loadout: null, autoStart: true },
   },
   {
     displayName: "Psyonix Allstar",
@@ -53,6 +53,6 @@ export const BASE_PLAYERS: DraggablePlayer[] = [
       skill: 3,
     }),
     tags: ["psyonix"],
-    overrides: { name: "", loadout: null, autoStart: true },
+    overrides: { name: null, loadout: null, autoStart: true },
   },
 ];

--- a/frontend/src/components/Teams/PlayerOverridesModal.svelte
+++ b/frontend/src/components/Teams/PlayerOverridesModal.svelte
@@ -13,8 +13,7 @@ let {
 
 function clearOverrides() {
   if (player) {
-    player.overrides.name =
-      player.info instanceof PsyonixBotInfo ? "" : player.displayName;
+    player.overrides.name = null;
     player.overrides.loadout = null;
     player.overrides.autoStart = true;
   }
@@ -22,8 +21,7 @@ function clearOverrides() {
 
 function hasNameOverride(): boolean {
   if (!player) return false;
-  let expectedName = player.info instanceof BotInfo ? player.displayName : "";
-  return player.overrides.name !== expectedName;
+  return player.overrides.name !== null;
 }
 
 async function pickLoadoutOverride() {
@@ -39,9 +37,12 @@ async function pickLoadoutOverride() {
     <p style={hasNameOverride() ? "color: orange;" : ""}>In-game name:</p>
     <input
             type="text"
-            placeholder="Bot name"
+            placeholder=""
             id={`edit-name-${player.id}`}
-            bind:value={player.overrides.name}
+            bind:value={
+                () => player?.overrides.name ?? player.displayName,
+                (v) => player.overrides.name = (v === player.displayName) ? null : v
+            }
     >
     <br />
     <br />

--- a/frontend/src/components/Teams/TeamBotList.svelte
+++ b/frontend/src/components/Teams/TeamBotList.svelte
@@ -65,9 +65,8 @@ function canAutoStart(d: DraggablePlayer): boolean {
 }
 
 function hasOverrides(d: DraggablePlayer): boolean {
-  let expectedName = d.info instanceof BotInfo ? d.displayName : "";
   return (
-    d.overrides.name !== expectedName ||
+    d.overrides.name !== null ||
     !d.overrides.autoStart ||
     d.overrides.loadout != null
   );
@@ -169,7 +168,7 @@ const dnd_container_namespace = `team_${crypto.randomUUID()}`;
               ? "filter: brightness(var(--icon-brightness))" : ""
             }
           />
-          <p>{bot.displayName === bot.overrides.name || (bot.info instanceof PsyonixBotInfo && bot.overrides.name === "") ? bot.displayName : `${bot.overrides.name}`}</p>
+          <p>{bot.overrides.name === null ? bot.displayName : bot.overrides.name}</p>
           {#if bot.uniquePathSegment}
             <span class="unique-bot-identifier">({bot.uniquePathSegment})</span>
           {/if}

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -49,7 +49,7 @@ export function parseSuperJSON(item: string | null): any | null {
 }
 
 export interface PlayerFieldOverrides {
-  name: string;
+  name: string | null;
   loadout: LoadoutConfig | null;
   autoStart: boolean;
 }
@@ -77,7 +77,7 @@ export function draggablePlayerToPlayerJs(d: DraggablePlayer): PlayerJs {
   if (d.info instanceof BotInfo) {
     const player = BotInfo.createFrom(structuredClone(d.info));
     // Apply overrides
-    player.config.settings.name = d.overrides.name;
+    player.config.settings.name = d.overrides.name ?? player.config.settings.name;
     player.loadout = d.overrides.loadout ?? d.info.loadout;
     if (!d.overrides.autoStart) {
       player.config.settings.runCommand = "";
@@ -96,7 +96,7 @@ export function draggablePlayerToPlayerJs(d: DraggablePlayer): PlayerJs {
   if (d.info instanceof PsyonixBotInfo) {
     const player = PsyonixBotInfo.createFrom(structuredClone(d.info));
     // Apply overrides
-    player.name = d.overrides.name;
+    player.name = d.overrides.name ?? "";  // Emptry string means random name for Psyonix bots
     player.loadout = d.overrides.loadout ?? d.info.loadout;
 
     return {

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -77,7 +77,8 @@ export function draggablePlayerToPlayerJs(d: DraggablePlayer): PlayerJs {
   if (d.info instanceof BotInfo) {
     const player = BotInfo.createFrom(structuredClone(d.info));
     // Apply overrides
-    player.config.settings.name = d.overrides.name ?? player.config.settings.name;
+    player.config.settings.name =
+      d.overrides.name ?? player.config.settings.name;
     player.loadout = d.overrides.loadout ?? d.info.loadout;
     if (!d.overrides.autoStart) {
       player.config.settings.runCommand = "";
@@ -96,7 +97,7 @@ export function draggablePlayerToPlayerJs(d: DraggablePlayer): PlayerJs {
   if (d.info instanceof PsyonixBotInfo) {
     const player = PsyonixBotInfo.createFrom(structuredClone(d.info));
     // Apply overrides
-    player.name = d.overrides.name ?? "";  // Emptry string means random name for Psyonix bots
+    player.name = d.overrides.name ?? ""; // Empty names are replaced with random names for Psyonix bots
     player.loadout = d.overrides.loadout ?? d.info.loadout;
 
     return {

--- a/frontend/src/pages/Home.svelte
+++ b/frontend/src/pages/Home.svelte
@@ -332,15 +332,12 @@ async function getLatestBotInfo(tomlPath: string): Promise<BotInfo | null> {
     );
 
     if (index !== -1) {
-      players[index] = {
-        ...players[index],
-        displayName: found.config.settings.name,
-        icon: found.icon,
-        info: botInfo,
-        tags: found.config.details.tags,
-      };
 
-      players = [...players];
+      players[index].info = botInfo
+      players[index].displayName = found.config.settings.name
+      players[index].icon = found.icon
+      players[index].tags = found.config.details.tags
+
       bluePlayers = updateTeam(bluePlayers);
       orangePlayers = updateTeam(orangePlayers);
     }
@@ -365,22 +362,14 @@ async function getLatestScriptInfo(tomlPath: string): Promise<BotInfo | null> {
       const oldAgentId = scripts[index].info.config.settings.agentId;
       const newAgentId = found.config.settings.agentId;
 
-      scripts[index] = {
-        ...scripts[index],
-        displayName: found.config.settings.name,
-        icon: found.config.settings.logoFile,
-        info: found,
-        tags: found.config.details.tags,
-      };
+      scripts[index].displayName = found.config.settings.name
+      scripts[index].icon = found.config.settings.logoFile
+      scripts[index].info = found
+      scripts[index].tags = found.config.details.tags
 
-      scripts = [...scripts];
-
-      if (enabledScripts[newAgentId] === undefined) {
-        enabledScripts[newAgentId] = false;
-      }
-
-      if (oldAgentId !== newAgentId && enabledScripts[oldAgentId] === undefined) {
-        enabledScripts[oldAgentId] = false;
+      enabledScripts[newAgentId] = enabledScripts[oldAgentId]
+      if (oldAgentId !== newAgentId) {
+        delete enabledScripts[oldAgentId]
       }
     }
 

--- a/frontend/src/pages/Home.svelte
+++ b/frontend/src/pages/Home.svelte
@@ -272,7 +272,7 @@ async function updateBots() {
         tags: x.config.details.tags,
         uniquePathSegment,
         overrides: {
-          name: x.config.settings.name,
+          name: null,
           loadout: null,
           autoStart: true,
         },


### PR DESCRIPTION
Now use `null` to indicate that the name is not overridden.

This removes a quirk revealed in #112. If a bot had had its name changed in the toml, then after the reload, the old name would be considered an override.