### PR TITLE
Add libtorch to PATH for botpack bots

### DIFF
--- a/build/Taskfile.yml
+++ b/build/Taskfile.yml
@@ -16,7 +16,7 @@ tasks:
     generates:
       - node_modules
     preconditions:
-      - sh: pnpm version
+      - sh: pnpm --version
         msg: "Looks like pnpm isn't installed."
     cmds:
       - pnpm install

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "svelte-portal": "^2.2.1"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.3.9",
+    "@biomejs/biome": "^2.5.1",
     "@sveltejs/vite-plugin-svelte": "^6.2.1",
     "typescript": "^5.9.3",
     "vite": "npm:vite@7.3.1"

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
         version: 2.2.1
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.3.9
-        version: 2.3.9
+        specifier: ^2.5.1
+        version: 2.5.1
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.2.1
         version: 6.2.4(svelte@5.46.0)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1))
@@ -42,59 +42,59 @@ importers:
 
 packages:
 
-  '@biomejs/biome@2.3.9':
-    resolution: {integrity: sha512-js+34KpnY65I00k8P71RH0Uh2rJk4BrpxMGM5m2nBfM9XTlKE5N1URn5ydILPRyXXq4ebhKCjsvR+txS+D4z2A==}
+  '@biomejs/biome@2.5.1':
+    resolution: {integrity: sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.3.9':
-    resolution: {integrity: sha512-hHbYYnna/WBwem5iCpssQQLtm5ey8ADuDT8N2zqosk6LVWimlEuUnPy6Mbzgu4GWVriyL5ijWd+1zphX6ll4/A==}
+  '@biomejs/cli-darwin-arm64@2.5.1':
+    resolution: {integrity: sha512-npqDzvqv7vFaWRiNN1Te71siRgPaqS9MpqgYCdP/CrUbkJ7ApezaeaKjueKHRN/JH/6lRjJQAHi8acQDCAz22w==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.3.9':
-    resolution: {integrity: sha512-sKMW5fpvGDmPdqCchtVH5MVlbVeSU3ad4CuKS45x8VHt3tNSC8CZ2QbxffAOKYK9v/mAeUiPC6Cx6+wtyU1q7g==}
+  '@biomejs/cli-darwin-x64@2.5.1':
+    resolution: {integrity: sha512-RgwTqPAM8g2tn1j+b5oRjF/DbSBX8a4gwojtuG9XuhfK7GgomvZ9+T+tqjXiVbjLEeGJOoL6VEk8mvRTVeSybw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.3.9':
-    resolution: {integrity: sha512-JOHyG2nl8XDpncbMazm1uBSi1dPX9VbQDOjKcfSVXTqajD0PsgodMOKyuZ/PkBu5Lw877sWMTGKfEfpM7jE7Cw==}
+  '@biomejs/cli-linux-arm64-musl@2.5.1':
+    resolution: {integrity: sha512-WMcvMLgByyTqVxGlq918NBBYliq9FRR9GAQVETHb+VjGVqXCZFfHlZHC1FX4ibuYY/Hg6TJE3rHU0xVrdJXNRw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.3.9':
-    resolution: {integrity: sha512-BXBB6HbAgZI6T6QB8q6NSwIapVngqArP6K78BqkMerht7YjL6yWctqfeTnJm0qGF2bKBYFexslrbV+VTlM2E6g==}
+  '@biomejs/cli-linux-arm64@2.5.1':
+    resolution: {integrity: sha512-yhV35CzZh38VyMvTEXi3JTjxZBs++oCKK9KG8vB6VI5+uvQvZNR3BFWEKKzuOmx9DJJj7sQpZ4LQJcmbGTs3+Q==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.3.9':
-    resolution: {integrity: sha512-FUkb/5beCIC2trpqAbW9e095X4vamdlju80c1ExSmhfdrojLZnWkah/XfTSixKb/dQzbAjpD7vvs6rWkJ+P07Q==}
+  '@biomejs/cli-linux-x64-musl@2.5.1':
+    resolution: {integrity: sha512-ANTowtlLmPYm5yeMckWY8Xzb9Ix+JJP3tgHR/n6xRj1VWyIzzWtfRfih9hv9VmClwadpBvZduISZIbBsIlYG3A==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.3.9':
-    resolution: {integrity: sha512-PjYuv2WLmvf0WtidxAkFjlElsn0P6qcvfPijrqu1j+3GoW3XSQh3ywGu7gZ25J25zrYj3KEovUjvUZB55ATrGw==}
+  '@biomejs/cli-linux-x64@2.5.1':
+    resolution: {integrity: sha512-J/7uHSX7NfoYDI7HijAkd8lnQIOrRb2W7j3X+tw4R+N5ExvXGsyXFiGdQcfcxfOmNQmZVSQOCDk757fwpzqQcg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.3.9':
-    resolution: {integrity: sha512-w48Yh/XbYHO2cBw8B5laK3vCAEKuocX5ItGXVDAqFE7Ze2wnR00/1vkY6GXglfRDOjWHu2XtxI0WKQ52x1qxEA==}
+  '@biomejs/cli-win32-arm64@2.5.1':
+    resolution: {integrity: sha512-zgXnKNgWPC4iPF7Y1lR3STUeCUuZRpD6IiOrC7TZTlh0Lx6FiVUT05myuMQHQ9D+1cc7uyMldi4forE6lp0ivQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.3.9':
-    resolution: {integrity: sha512-90+J63VT7qImy9s3pkWL0ZX27VzVwMNCRzpLpe5yMzMYPbO1vcjL/w/Q5f/juAGMvP7a2Fd0H7IhAR6F7/i78A==}
+  '@biomejs/cli-win32-x64@2.5.1':
+    resolution: {integrity: sha512-6uxpR9hvaglANkZemeSiN/FhYgkGasrEGn267eXIWvjrjJ2LhDlk251IhjVJq6MXzkV2/bcXwLwSroLyPtqRZg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -699,39 +699,39 @@ packages:
 
 snapshots:
 
-  '@biomejs/biome@2.3.9':
+  '@biomejs/biome@2.5.1':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.3.9
-      '@biomejs/cli-darwin-x64': 2.3.9
-      '@biomejs/cli-linux-arm64': 2.3.9
-      '@biomejs/cli-linux-arm64-musl': 2.3.9
-      '@biomejs/cli-linux-x64': 2.3.9
-      '@biomejs/cli-linux-x64-musl': 2.3.9
-      '@biomejs/cli-win32-arm64': 2.3.9
-      '@biomejs/cli-win32-x64': 2.3.9
+      '@biomejs/cli-darwin-arm64': 2.5.1
+      '@biomejs/cli-darwin-x64': 2.5.1
+      '@biomejs/cli-linux-arm64': 2.5.1
+      '@biomejs/cli-linux-arm64-musl': 2.5.1
+      '@biomejs/cli-linux-x64': 2.5.1
+      '@biomejs/cli-linux-x64-musl': 2.5.1
+      '@biomejs/cli-win32-arm64': 2.5.1
+      '@biomejs/cli-win32-x64': 2.5.1
 
-  '@biomejs/cli-darwin-arm64@2.3.9':
+  '@biomejs/cli-darwin-arm64@2.5.1':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.3.9':
+  '@biomejs/cli-darwin-x64@2.5.1':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.3.9':
+  '@biomejs/cli-linux-arm64-musl@2.5.1':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.3.9':
+  '@biomejs/cli-linux-arm64@2.5.1':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.3.9':
+  '@biomejs/cli-linux-x64-musl@2.5.1':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.3.9':
+  '@biomejs/cli-linux-x64@2.5.1':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.3.9':
+  '@biomejs/cli-win32-arm64@2.5.1':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.3.9':
+  '@biomejs/cli-win32-x64@2.5.1':
     optional: true
 
   '@esbuild/aix-ppc64@0.27.3':

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.4
 
 require (
 	github.com/BurntSushi/toml v1.5.0
-	github.com/RLBot/go-interface v0.0.0-20260605164522-430c99d64f89
+	github.com/RLBot/go-interface v0.0.0-20260629182020-8b91debb011c
 	github.com/ncruces/zenity v0.10.14
 	github.com/ulikunitz/xz v0.5.15
 	github.com/wailsapp/mimetype v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.3.0 h1:ILq8+Sf5If5DCpHQp4PbZdS1J7HDFRXz/+xKBiRGFrw=
 github.com/ProtonMail/go-crypto v1.3.0/go.mod h1:9whxjD8Rbs29b4XWbB8irEcE8KHMqaR2e7GWU1R+/PE=
-github.com/RLBot/go-interface v0.0.0-20260605164522-430c99d64f89 h1:VKIWXsYi6xyZ+jfOM7n6yZH5aDHFj1ZRorUPN5qSOqo=
-github.com/RLBot/go-interface v0.0.0-20260605164522-430c99d64f89/go.mod h1:h1OFzIrmgkjVcRrRSKlTjRAMWwZzD8APhem7ZzPDkmw=
+github.com/RLBot/go-interface v0.0.0-20260629182020-8b91debb011c h1:z6vnbtsahs5emfPBovWR3snZaLZonSEqQa5hn3kdJe8=
+github.com/RLBot/go-interface v0.0.0-20260629182020-8b91debb011c/go.mod h1:h1OFzIrmgkjVcRrRSKlTjRAMWwZzD8APhem7ZzPDkmw=
 github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
 github.com/adrg/xdg v0.5.3/go.mod h1:nlTsY+NNiCBGCK2tpm09vRqfVzrc2fLmXGpBLF0zlTQ=
 github.com/akavel/rsrc v0.10.2 h1:Zxm8V5eI1hW4gGaYsJQUhxpjkENuG91ki8B4zCrvEsw=

--- a/justfile
+++ b/justfile
@@ -12,4 +12,4 @@ lint:
 
 format:
     go fmt
-    cd frontend && biome format --fix
+    cd frontend && pnpm biome format --fix

--- a/players.go
+++ b/players.go
@@ -166,6 +166,55 @@ type BotInfo struct {
 	Icon     string         `json:"icon"`
 }
 
+// findTorchLibDir walks up the directory tree from the given path,
+// checking each ancestor for a torch-archive/torch/lib directory.
+// Returns the full path to the lib directory if found, or "" if not.
+func findTorchLibDir(fromPath string) string {
+	dir := fromPath
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		dir = filepath.Dir(dir)
+	}
+	for i := 0; i < 5; i++ {
+		candidate := filepath.Join(dir, "torch-archive", "torch", "lib")
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return candidate
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return ""
+}
+
+// setTorchEnv populates the Environment field with PATH/LD_LIBRARY_PATH
+// pointing to the torch-archive lib directory, if it exists.
+func setTorchEnv(tomlPath string, env *[]*flat.EnvironmentVariableT) {
+	torchLibDir := findTorchLibDir(tomlPath)
+	if torchLibDir == "" {
+		return
+	}
+
+	if runtime.GOOS == "windows" {
+		*env = append(*env, &flat.EnvironmentVariableT{
+			Name:  "PATH",
+			Value: torchLibDir + ";" + os.Getenv("PATH"),
+		})
+	} else {
+		ldLibPath := os.Getenv("LD_LIBRARY_PATH")
+		if ldLibPath != "" {
+			ldLibPath = torchLibDir + ":" + ldLibPath
+		} else {
+			ldLibPath = torchLibDir
+		}
+		*env = append(*env, &flat.EnvironmentVariableT{
+			Name:  "LD_LIBRARY_PATH",
+			Value: ldLibPath,
+		})
+	}
+}
+
 func (botInfo BotInfo) ToPlayerConfig(team uint32) *flat.PlayerConfigurationT {
 	var runCommand string
 	if runtime.GOOS == "windows" {
@@ -186,17 +235,21 @@ func (botInfo BotInfo) ToPlayerConfig(team uint32) *flat.PlayerConfigurationT {
 		loadout = teamLoadout.ToPlayerLoadout()
 	}
 
+	customBot := &flat.CustomBotT{
+		Name:       botInfo.Config.Settings.Name,
+		AgentId:    botInfo.Config.Settings.AgentId,
+		RootDir:    botInfo.Config.Settings.RootDir,
+		RunCommand: runCommand,
+		Loadout:    loadout,
+		Hivemind:   botInfo.Config.Settings.Hivemind,
+	}
+
+	setTorchEnv(botInfo.TomlPath, &customBot.Environment)
+
 	return &flat.PlayerConfigurationT{
 		Variety: &flat.PlayerClassT{
-			Type: flat.PlayerClassCustomBot,
-			Value: &flat.CustomBotT{
-				Name:       botInfo.Config.Settings.Name,
-				AgentId:    botInfo.Config.Settings.AgentId,
-				RootDir:    botInfo.Config.Settings.RootDir,
-				RunCommand: runCommand,
-				Loadout:    loadout,
-				Hivemind:   botInfo.Config.Settings.Hivemind,
-			},
+			Type:  flat.PlayerClassCustomBot,
+			Value: customBot,
 		},
 		Team:     team,
 		PlayerId: 0, // let core do this

--- a/scripts.go
+++ b/scripts.go
@@ -20,13 +20,17 @@ func (botInfo BotInfo) ToScriptConfig() *flat.ScriptConfigurationT {
 		runCommand = botInfo.Config.Settings.RunCommandLinux
 	}
 
-	return &flat.ScriptConfigurationT{
+	scriptConfig := &flat.ScriptConfigurationT{
 		Name:       botInfo.Config.Settings.Name,
 		AgentId:    botInfo.Config.Settings.AgentId,
 		RootDir:    botInfo.Config.Settings.RootDir,
 		RunCommand: runCommand,
 		ScriptId:   0, // let core do this
 	}
+
+	setTorchEnv(botInfo.TomlPath, &scriptConfig.Environment)
+
+	return scriptConfig
 }
 
 func (a *App) GetScripts(paths []string) []BotInfo {


### PR DESCRIPTION
- Works on Window & Linux
- Enables C++-only GGL bots in the botpack
- Only works for botpack bots
  - Other bots may use a different version of torch! we don't want to mess them up. they can configure torch separately.