### PR TITLE
Read env vars from agent configs

### DIFF
--- a/frontend/src/components/BotList.svelte
+++ b/frontend/src/components/BotList.svelte
@@ -210,7 +210,6 @@ function filterBots(
 }
 
 function scriptDuplicateAgentIdWarning(d: ToggleableScript): string | null {
-
   const agentId = d.info.config.settings.agentId;
 
   if (!agentId) {

--- a/frontend/src/components/Teams/TeamBotList.svelte
+++ b/frontend/src/components/Teams/TeamBotList.svelte
@@ -12,7 +12,7 @@ import cannotAutoRunIcon from "../../assets/cannot_play.svg";
 import defaultIcon from "../../assets/rlbot_mono.png";
 
 import PlayerOverridesModal from "./PlayerOverridesModal.svelte";
-import {Browser} from "@wailsio/runtime";
+import { Browser } from "@wailsio/runtime";
 import warningIcon from "../../assets/exclamation-triangle-fill.svg";
 
 let {

--- a/frontend/src/pages/Home.svelte
+++ b/frontend/src/pages/Home.svelte
@@ -186,7 +186,7 @@ function collectDuplicateAgentIds(
   bots: DraggablePlayer[],
   scripts: ToggleableScript[],
 ): Set<string> {
-  const agentIdTomlMap: { [id: string]: string } = {}
+  const agentIdTomlMap: { [id: string]: string } = {};
   const duplicateAgentIds = new Set<string>();
 
   for (const bot of bots) {

--- a/players.go
+++ b/players.go
@@ -244,6 +244,15 @@ func (botInfo BotInfo) ToPlayerConfig(team uint32) *flat.PlayerConfigurationT {
 		Hivemind:   botInfo.Config.Settings.Hivemind,
 	}
 
+	// Add environment variables from the bot's config toml first
+	for k, v := range botInfo.Config.Settings.Environment {
+		customBot.Environment = append(customBot.Environment, &flat.EnvironmentVariableT{
+			Name:  k,
+			Value: v,
+		})
+	}
+
+	// Then append torch paths (if found) so they combine properly with any toml-specified paths
 	setTorchEnv(botInfo.TomlPath, &customBot.Environment)
 
 	return &flat.PlayerConfigurationT{
@@ -279,6 +288,8 @@ type BotSettings struct {
 	RunCommandLinux string `toml:"run_command_linux" json:"runCommandLinux"`
 	// If bot can handle multiple agents with one client
 	Hivemind bool `toml:"hivemind" json:"hivemind"`
+	// Additional environment variables to set for the bot process
+	Environment map[string]string `toml:"environment" json:"environment"`
 }
 
 type BotDetails struct {

--- a/players.go
+++ b/players.go
@@ -199,8 +199,8 @@ func pathSeparator() string {
 
 // resolveEnvironmentVariables resolves path-like prepend/postpend markers in
 // environment variable values. If a value starts with the platform path
-// separator, it is prepended to the current value (falling back to os.Getenv).
-// If it ends with the separator, it is postpended. Otherwise the value is used
+// separator, it is appended to the current value (falling back to os.Getenv).
+// If it ends with the separator, it is prepended. Otherwise the value is used
 // as-is.
 func resolveEnvironmentVariables(env []*flat.EnvironmentVariableT) []*flat.EnvironmentVariableT {
 	sep := pathSeparator()
@@ -219,14 +219,14 @@ func resolveEnvironmentVariables(env []*flat.EnvironmentVariableT) []*flat.Envir
 			if existing == "" {
 				value = cleanValue
 			} else {
-				value = cleanValue + sep + existing
+				value = existing + sep + cleanValue
 			}
 		} else if strings.HasSuffix(value, sep) {
 			cleanValue := strings.TrimSuffix(value, sep)
 			if existing == "" {
 				value = cleanValue
 			} else {
-				value = existing + sep + cleanValue
+				value = cleanValue + sep + existing
 			}
 		}
 
@@ -242,7 +242,7 @@ func resolveEnvironmentVariables(env []*flat.EnvironmentVariableT) []*flat.Envir
 
 // setTorchEnv appends a PATH/LD_LIBRARY_PATH entry pointing to the
 // torch-archive lib directory, if it exists. The value begins with the
-// platform path separator so resolveEnvironmentVariables prepends it to the
+// platform path separator so resolveEnvironmentVariables appends it to the
 // existing path.
 func setTorchEnv(tomlPath string, env *[]*flat.EnvironmentVariableT) {
 	torchLibDir := findTorchLibDir(tomlPath)

--- a/players.go
+++ b/players.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 	"github.com/RLBot/go-interface/flat"
@@ -188,31 +189,83 @@ func findTorchLibDir(fromPath string) string {
 	return ""
 }
 
-// setTorchEnv populates the Environment field with PATH/LD_LIBRARY_PATH
-// pointing to the torch-archive lib directory, if it exists.
+// pathSeparator returns the platform-specific path list separator as a string.
+func pathSeparator() string {
+	if runtime.GOOS == "windows" {
+		return ";"
+	}
+	return ":"
+}
+
+// resolveEnvironmentVariables resolves path-like prepend/postpend markers in
+// environment variable values. If a value starts with the platform path
+// separator, it is prepended to the current value (falling back to os.Getenv).
+// If it ends with the separator, it is postpended. Otherwise the value is used
+// as-is.
+func resolveEnvironmentVariables(env []*flat.EnvironmentVariableT) []*flat.EnvironmentVariableT {
+	sep := pathSeparator()
+	resolvedMap := make(map[string]string)
+	result := make([]*flat.EnvironmentVariableT, 0, len(env))
+
+	for _, ev := range env {
+		existing := resolvedMap[ev.Name]
+		if existing == "" {
+			existing = os.Getenv(ev.Name)
+		}
+
+		value := ev.Value
+		if strings.HasPrefix(value, sep) {
+			cleanValue := strings.TrimPrefix(value, sep)
+			if existing == "" {
+				value = cleanValue
+			} else {
+				value = cleanValue + sep + existing
+			}
+		} else if strings.HasSuffix(value, sep) {
+			cleanValue := strings.TrimSuffix(value, sep)
+			if existing == "" {
+				value = cleanValue
+			} else {
+				value = existing + sep + cleanValue
+			}
+		}
+
+		resolvedMap[ev.Name] = value
+		result = append(result, &flat.EnvironmentVariableT{
+			Name:  ev.Name,
+			Value: value,
+		})
+	}
+
+	return result
+}
+
+// setTorchEnv appends a PATH/LD_LIBRARY_PATH entry pointing to the
+// torch-archive lib directory, if it exists. The value begins with the
+// platform path separator so resolveEnvironmentVariables prepends it to the
+// existing path.
 func setTorchEnv(tomlPath string, env *[]*flat.EnvironmentVariableT) {
 	torchLibDir := findTorchLibDir(tomlPath)
 	if torchLibDir == "" {
 		return
 	}
 
+	varName := "LD_LIBRARY_PATH"
 	if runtime.GOOS == "windows" {
-		*env = append(*env, &flat.EnvironmentVariableT{
-			Name:  "PATH",
-			Value: torchLibDir + ";" + os.Getenv("PATH"),
-		})
-	} else {
-		ldLibPath := os.Getenv("LD_LIBRARY_PATH")
-		if ldLibPath != "" {
-			ldLibPath = torchLibDir + ":" + ldLibPath
-		} else {
-			ldLibPath = torchLibDir
-		}
-		*env = append(*env, &flat.EnvironmentVariableT{
-			Name:  "LD_LIBRARY_PATH",
-			Value: ldLibPath,
-		})
+		varName = "PATH"
 	}
+
+	for _, ev := range *env {
+		if ev.Name == varName {
+			return
+		}
+	}
+
+	sep := pathSeparator()
+	*env = append(*env, &flat.EnvironmentVariableT{
+		Name:  varName,
+		Value: sep + torchLibDir,
+	})
 }
 
 func (botInfo BotInfo) ToPlayerConfig(team uint32) *flat.PlayerConfigurationT {
@@ -254,6 +307,8 @@ func (botInfo BotInfo) ToPlayerConfig(team uint32) *flat.PlayerConfigurationT {
 
 	// Then append torch paths (if found) so they combine properly with any toml-specified paths
 	setTorchEnv(botInfo.TomlPath, &customBot.Environment)
+
+	customBot.Environment = resolveEnvironmentVariables(customBot.Environment)
 
 	return &flat.PlayerConfigurationT{
 		Variety: &flat.PlayerClassT{

--- a/sandbox.go
+++ b/sandbox.go
@@ -462,28 +462,36 @@ func simplifyGamePacket(gp *flat.GamePacketT) SandboxGamePacket {
 
 	if len(gp.Balls) > 0 && gp.Balls[0] != nil && gp.Balls[0].Physics != nil {
 		phys := gp.Balls[0].Physics
-		pkt.Ball.Physics = SandboxPhysics{
-			Location: SandboxVec3{
+		physics := SandboxPhysics{}
+		if phys.Location != nil {
+			physics.Location = SandboxVec3{
 				X: phys.Location.X,
 				Y: phys.Location.Y,
 				Z: phys.Location.Z,
-			},
-			Rotation: SandboxRot3{
+			}
+		}
+		if phys.Rotation != nil {
+			physics.Rotation = SandboxRot3{
 				Pitch: phys.Rotation.Pitch,
 				Yaw:   phys.Rotation.Yaw,
 				Roll:  phys.Rotation.Roll,
-			},
-			Velocity: SandboxVec3{
+			}
+		}
+		if phys.Velocity != nil {
+			physics.Velocity = SandboxVec3{
 				X: phys.Velocity.X,
 				Y: phys.Velocity.Y,
 				Z: phys.Velocity.Z,
-			},
-			AngularVelocity: SandboxVec3{
+			}
+		}
+		if phys.AngularVelocity != nil {
+			physics.AngularVelocity = SandboxVec3{
 				X: phys.AngularVelocity.X,
 				Y: phys.AngularVelocity.Y,
 				Z: phys.AngularVelocity.Z,
-			},
+			}
 		}
+		pkt.Ball.Physics = physics
 	}
 
 	pkt.Cars = make([]SandboxCar, len(gp.Players))
@@ -499,28 +507,36 @@ func simplifyGamePacket(gp *flat.GamePacketT) SandboxGamePacket {
 			Name:  player.Name,
 		}
 		if player.Physics != nil {
-			car.Physics = SandboxPhysics{
-				Location: SandboxVec3{
+			physics := SandboxPhysics{}
+			if player.Physics.Location != nil {
+				physics.Location = SandboxVec3{
 					X: player.Physics.Location.X,
 					Y: player.Physics.Location.Y,
 					Z: player.Physics.Location.Z,
-				},
-				Rotation: SandboxRot3{
+				}
+			}
+			if player.Physics.Rotation != nil {
+				physics.Rotation = SandboxRot3{
 					Pitch: player.Physics.Rotation.Pitch,
 					Yaw:   player.Physics.Rotation.Yaw,
 					Roll:  player.Physics.Rotation.Roll,
-				},
-				Velocity: SandboxVec3{
+				}
+			}
+			if player.Physics.Velocity != nil {
+				physics.Velocity = SandboxVec3{
 					X: player.Physics.Velocity.X,
 					Y: player.Physics.Velocity.Y,
 					Z: player.Physics.Velocity.Z,
-				},
-				AngularVelocity: SandboxVec3{
+				}
+			}
+			if player.Physics.AngularVelocity != nil {
+				physics.AngularVelocity = SandboxVec3{
 					X: player.Physics.AngularVelocity.X,
 					Y: player.Physics.AngularVelocity.Y,
 					Z: player.Physics.AngularVelocity.Z,
-				},
+				}
 			}
+			car.Physics = physics
 		}
 		pkt.Cars[i] = car
 	}

--- a/scripts.go
+++ b/scripts.go
@@ -39,6 +39,8 @@ func (botInfo BotInfo) ToScriptConfig() *flat.ScriptConfigurationT {
 	// Then append torch paths (if found) so they combine properly with any toml-specified paths
 	setTorchEnv(botInfo.TomlPath, &scriptConfig.Environment)
 
+	scriptConfig.Environment = resolveEnvironmentVariables(scriptConfig.Environment)
+
 	return scriptConfig
 }
 

--- a/scripts.go
+++ b/scripts.go
@@ -28,6 +28,15 @@ func (botInfo BotInfo) ToScriptConfig() *flat.ScriptConfigurationT {
 		ScriptId:   0, // let core do this
 	}
 
+	// Add environment variables from the script's config toml first
+	for k, v := range botInfo.Config.Settings.Environment {
+		scriptConfig.Environment = append(scriptConfig.Environment, &flat.EnvironmentVariableT{
+			Name:  k,
+			Value: v,
+		})
+	}
+
+	// Then append torch paths (if found) so they combine properly with any toml-specified paths
 	setTorchEnv(botInfo.TomlPath, &scriptConfig.Environment)
 
 	return scriptConfig


### PR DESCRIPTION
This example now works from the gui when added outside the botpack:

```toml
[details]
description = ""
developer = "The RLBot community"
fun_fact = "Made with GigaLearn"
language = "C++"
source_link = ""
tags = ["1v1", "teamplay"]

[settings]
agent_id = "VirxEC/Veai/ggl"
loadout_file = "loadout.toml"
logo_file = "logo.png"
name = "Veai (GGL)"
run_command = 'x86_64-pc-windows-msvc\\GGLBot.exe'
run_command_linux = "x86_64-unknown-linux-gnu/GGLBot"
environment = { "LD_LIBRARY_PATH" = "/home/virx/.local/share/RLBot5/bots/torch-archive/torch/lib/" }
```